### PR TITLE
Feat: CategoryChip 컴포넌트

### DIFF
--- a/packages/ui/src/components/category-chip.tsx
+++ b/packages/ui/src/components/category-chip.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { cva, type VariantProps } from 'class-variance-authority';
+import * as React from 'react';
+import { cn } from '../lib/utils';
+
+const categoryChipVariants = cva(
+  cn(
+    'inline-flex items-center leading-none px-2 py-1 rounded-lg',
+    'select-none',
+    'text-xs font-normal'
+  ),
+  {
+    variants: {
+      category: {
+        rating: 'bg-yellow-100 text-yellow-700',
+        study: 'bg-blue-100 text-blue-700',
+        etc: 'bg-gray-100 text-gray-700',
+        general: 'bg-green-100 text-green-700',
+        external: 'bg-purple-100 text-purple-700',
+      },
+    },
+    defaultVariants: {
+      category: 'rating',
+    },
+  }
+);
+
+const categoryText: Record<
+  NonNullable<VariantProps<typeof categoryChipVariants>['category']>,
+  string
+> = {
+  rating: '하이팅',
+  study: '스터디',
+  etc: '기타',
+  general: '학회일정',
+  external: '외부',
+};
+
+type CategoryChipProps = React.HTMLAttributes<HTMLSpanElement> &
+  VariantProps<typeof categoryChipVariants>;
+
+function CategoryChip({
+  className,
+  category = 'rating',
+  children,
+  ...props
+}: CategoryChipProps): React.ReactElement {
+  return (
+    <span data-slot="chip" className={cn(categoryChipVariants({ category }), className)} {...props}>
+      {children ?? categoryText[category ?? 'rating']}
+    </span>
+  );
+}
+
+export { CategoryChip };

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,4 +1,5 @@
 export * from './components/button';
-export * from './components/input';
 export * from './components/card';
+export * from './components/category-chip';
+export * from './components/input';
 export * from './lib/utils';


### PR DESCRIPTION
## 🔀 PR 개요
CategoryChip 컴포넌트 구현

<br/>

## 📌 주요 변경 사항
- CategoryChip 컴포넌트 구현
- 카테고리 enum을 기준으로 구현
  - category: rating, study, etc, general, external
  - category: 하이팅, 스터디, 기타, 학회일정, 외부

<br/>

## 📝 작업 상세 내용
주요 변경 사항과 동일

<br/>

## 🔗 관련 이슈/PR
- #1

<br/>

## 💬 기타 참고사항
tailwind-css 설정이 미흡한 상태이기에 tailwind-css 설정을 마친 후 수정할 예정입니다.