### PR TITLE
Fix: 수정된 tailwind-css에 맞게 CategoryChip 컴포넌트 수정

### DIFF
--- a/packages/ui/src/components/category-chip.tsx
+++ b/packages/ui/src/components/category-chip.tsx
@@ -13,11 +13,11 @@ const categoryChipVariants = cva(
   {
     variants: {
       category: {
-        rating: 'bg-yellow-100 text-yellow-700',
-        study: 'bg-blue-100 text-blue-700',
-        etc: 'bg-gray-100 text-gray-700',
-        general: 'bg-green-100 text-green-700',
-        external: 'bg-purple-100 text-purple-700',
+        rating: 'bg-category-rating/20 text-category-rating',
+        study: 'bg-category-study/20 text-category-study',
+        etc: 'bg-category-etc_background/20 text-category-etc',
+        general: 'bg-category-general/20 text-category-general',
+        external: 'bg-category-external/20 text-category-external',
       },
     },
     defaultVariants: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -32,7 +32,8 @@ module.exports = {
         category: {
           rating: '#00AAFF',
           study: '#FFAE2C',
-          etc: '#E7E700',
+          etc: '#ADAD00',
+          etc_background: '#E7E700',
           general: '#44D215',
           external: '#332AE8',
         },


### PR DESCRIPTION
## 🔀 PR 개요
<!--간단하게 PR 요약을 작성해주세요.-->
Fix: 수정된 tailwind-css에 맞게 CategoryChip 컴포넌트 수정

<br/>

## 📌 주요 변경 사항
<!--주요 변경점들을 작성해주세요.-->
- 카테고리에 맞게 색상 수정

<br/>

## 📝 작업 상세 내용
<!--작업 상세 내용을 작성해주세요.-->
rating, study, etc, general, external, 총 5개의 카테고리에 맞춰 색상 수정. etc의 경우 배경색이 opacity가 낮춰진 글자색을 사용하지 않고 별도의 색상을 사용하여 tailwind.config에 추가함.
<img width="189" height="98" alt="스크린샷 2025-07-20 오후 3 30 54" src="https://github.com/user-attachments/assets/10803894-0814-4572-966e-7f4cba6d1ce7" />


<br/>

## 🔗 관련 이슈/PR
<!--관련 이슈나 PR이 있다면 불릿 리스트 형식으로 작성하고 없다면 없음. 을 작성해주세요-->
- #1

<br/>

## 💬 기타 참고사항
<!--기타 참고할 만한 사항들이 있다면 작성해주세요. 없다면 비워놔도 좋습니다.-->

