### PR TITLE
Feat: 메인페이지 Layout

### DIFF
--- a/apps/intra/src/app/page.tsx
+++ b/apps/intra/src/app/page.tsx
@@ -1,25 +1,65 @@
-import { Button, Card, CardContent, CardHeader, CardTitle } from '@hiarc-platform/ui';
-import { formatDate } from '@hiarc-platform/util';
-
-export default function Home() {
+import { Title } from '@hiarc-platform/ui';
+import StudyCard from '@/ui/studyCard/StudyCard';
+import { Level } from 'constants/level';
+export default function Home(): React.ReactElement {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-between p-24">
-      <div className="z-10 w-full max-w-5xl items-center justify-between font-mono text-sm lg:flex">
-        <p className="fixed left-0 top-0 flex w-full justify-center border-b border-gray-300 bg-gradient-to-b from-zinc-200 pb-6 pt-8 backdrop-blur-2xl dark:border-neutral-800 dark:bg-zinc-800/30 dark:from-inherit lg:static lg:w-auto  lg:rounded-xl lg:border lg:bg-gray-200 lg:p-4 lg:dark:bg-zinc-800/30">
-          Admin Dashboard - {formatDate(new Date())}
-        </p>
-        <div className="fixed bottom-0 left-0 flex h-48 w-full items-end justify-center bg-gradient-to-t from-white via-white dark:from-black dark:via-black lg:static lg:h-auto lg:w-auto lg:bg-none">
-          <Card className="w-[350px]">
-            <CardHeader>
-              <CardTitle>Admin Stats</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <Button variant="line" size={'sm'} className="mt-4">
-                Manage Users
-              </Button>
-            </CardContent>
-          </Card>
-        </div>
+    <main className="n mt-8 flex min-h-screen  w-full  flex-col  px-[360px]">
+      {/*상단 임시로 높이 402px*/}
+      <div className="flex h-[402px] gap-4">
+        <section className="w-[50%]">
+          <Title size="sm" weight="bold" className="mb-2">
+            학회일정
+          </Title>
+        </section>
+        <section className="w-[50%]">
+          <Title size="sm" weight="bold" className="mb-2">
+            공지사항/알고리즘소식
+          </Title>
+        </section>
+      </div>
+
+      {/* 하단 */}
+      <div>
+        <section className="">
+          <Title size="sm" weight="bold" className="mb-2">
+            스터디목록
+          </Title>
+          <div className="grid grid-cols-2 gap-4 ">
+            <StudyCard
+              time="화,금 (8시)"
+              delivery="대면"
+              studyLevel={Level.BASIC}
+              studyTitle="초급스터디"
+              hostName="이가은"
+              startDate="2025.03.25"
+              endDate="2025.06.20"
+              studyDiscription="스터디 설명"
+              state="participating"
+            />
+            <StudyCard
+              time="화,금 (8시)"
+              delivery="대면"
+              studyLevel={Level.INTERMEDIATE}
+              studyTitle="초급스터디"
+              hostName="이태경"
+              startDate="2025.03.25"
+              endDate="2025.06.20"
+              studyDiscription="스터디 설명"
+              state="recruiting"
+            />
+            <StudyCard
+              time="화,금 (8시)"
+              delivery="비대면"
+              studyLevel={Level.EXPERT}
+              studyTitle="초급스터디"
+              hostName="송한서"
+              startDate="2025.03.25"
+              endDate="2025.06.20"
+              studyDiscription="스터디 설명"
+              state="participating"
+            />
+          </div>
+        </section>
       </div>
     </main>
   );

--- a/apps/intra/src/ui/studyCard/StudyCard.tsx
+++ b/apps/intra/src/ui/studyCard/StudyCard.tsx
@@ -28,7 +28,7 @@ export default function StudyCard({
   state,
 }: StudyCardProps): React.ReactElement {
   return (
-    <div className="flex h-[173px] w-[435px] flex-col gap-2 rounded-lg border border-gray-200  px-5 py-5">
+    <div className="flex h-[173px] min-w-[435px] flex-col gap-2 rounded-lg border border-gray-200  px-5 py-5">
       <div className="flex gap-2">
         <StudyGrayChip type="schedule" title={time} />
         <StudyGrayChip type="delivery" title={delivery} />


### PR DESCRIPTION
## 🔀 PR 개요
<!--간단하게 PR 요약을 작성해주세요.-->
main페이지 레이아웃을 간단하게 정의해놨습니다.

<br/>

## 📌 주요 변경 사항
<!--주요 변경점들을 작성해주세요.-->
- 스터디카드의 width가 기존에 만들어놓은 컴포넌트의 width와 달라 min-width를 435px로  바꾸고 그것보다 늘어나는것은 자유로 되게 바꾸었습니다.
- 스터디 목록 부분도 작성하였습니다.


<br/>

## 📝 작업 상세 내용
<!--작업 상세 내용을 작성해주세요.-->
- 스터디카드의 width가 기존에 만들어놓은 컴포넌트의 width와 달라 min-width를 435px로  바꾸고 그것보다 늘어나는것은 자유로 되게 바꾸었습니다.
- 스터디 목록 부분도 작성하였습니다.

<br/>

## 🔗 관련 이슈/PR
<!--관련 이슈나 PR이 있다면 불릿 리스트 형식으로 작성하고 없다면 없음. 을 작성해주세요-->
- #N

<br/>

## 💬 기타 참고사항
<!--기타 참고할 만한 사항들이 있다면 작성해주세요. 없다면 비워놔도 좋습니다.-->
아직 테이블 쓰는 것을 다 파악하지 못해서 이정도만 일단 푸쉬해봅니다.
다음 작업은 월요일에 계속하겠습니다!

