### PR TITLE
Feat: Admin/competition View 구현

### DIFF
--- a/apps/admin/src/app/competition/page.tsx
+++ b/apps/admin/src/app/competition/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { PageLayout } from '@hiarc-platform/ui';
 import { CompetitionTable } from '@/features/competition/components/competition-table';
 import { Competition } from '@/features/competition/components/competition-table/competition-list-column';
+import { CompetitionSearchButtons } from '@/features/competition/components/competition-bar/competition-search-buttons';
 
 const competitionData: Competition[] = [
   { name: 'John', title: '첫 번째 공지사항', date: '2025.10.01', number: 1, category: 'general' },
@@ -52,16 +53,18 @@ export default function CompetitonListPage(): React.ReactElement {
   const router = useRouter();
   return (
     <PageLayout>
-      <div className="flex justify-between">
-        <Title size="sm" weight="bold">
-          대회
-        </Title>
-        <Button size="md" className="w-[100px]" onClick={() => router.push('/study/information')}>
-          개설하기
-        </Button>
+      <div className="flex w-full flex-col gap-6 py-3">
+        <div className="flex justify-between">
+          <Title size="sm" weight="bold">
+            대회
+          </Title>
+          <Button size="md" className="w-[100px]" onClick={() => router.push('/study/information')}>
+            개설하기
+          </Button>
+        </div>
+        <CompetitionSearchButtons />
+        <CompetitionTable className="mt-6" data={competitionData} />
       </div>
-
-      <CompetitionTable className="mt-6" data={competitionData} />
     </PageLayout>
   );
 }

--- a/apps/admin/src/app/competition/page.tsx
+++ b/apps/admin/src/app/competition/page.tsx
@@ -6,7 +6,7 @@ import { PageLayout } from '@hiarc-platform/ui';
 import { CompetitionTable } from '@/features/competition/components/competition-table';
 import { Competition } from '@/features/competition/components/competition-table/competition-list-column';
 import { CompetitionSearchButtons } from '@/features/competition/components/competition-bar/competition-search-buttons';
-
+import { AddCompetitionModalTrigger } from '@/features/competition/components/add-competition-modal-trigger';
 const competitionData: Competition[] = [
   { name: 'John', title: '첫 번째 공지사항', date: '2025.10.01', number: 1, category: 'general' },
   { name: 'Jane', title: '두 번째 공지사항', date: '2025.10.02', number: 2, category: 'study' },
@@ -58,9 +58,7 @@ export default function CompetitonListPage(): React.ReactElement {
           <Title size="sm" weight="bold">
             대회
           </Title>
-          <Button size="md" className="w-[100px]" onClick={() => router.push('/study/information')}>
-            개설하기
-          </Button>
+          <AddCompetitionModalTrigger />
         </div>
         <CompetitionSearchButtons />
         <CompetitionTable className="mt-6" data={competitionData} />

--- a/apps/admin/src/features/competition/components/add-competition-modal-trigger/award-record-form.tsx
+++ b/apps/admin/src/features/competition/components/add-competition-modal-trigger/award-record-form.tsx
@@ -1,0 +1,57 @@
+'use client';
+import { Button, LabeledInput, LabeledSelectButton } from '@hiarc-platform/ui';
+import { useState } from 'react';
+import { selectOption } from 'constants/selectOption';
+
+interface AwardRecordFormProps {
+  onDelete(): void;
+}
+
+export function AwardRecordForm({ onDelete }: AwardRecordFormProps): React.ReactElement {
+  const [oauth, setOauth] = useState<boolean>(false);
+  const [isAward, setIsAward] = useState<boolean>(false);
+  return (
+    <div className="flex w-full gap-3">
+      <div className="flex w-full flex-col gap-2">
+        <div className="flex w-full items-end gap-2">
+          <LabeledInput label="핸들명" placeholder="핸들명 입력하기" disabled={oauth} />
+          {oauth ? (
+            <LabeledSelectButton
+              label="기록 유형"
+              options={['참여', '수상']}
+              onChange={(value) => setIsAward(value === '수상')}
+            />
+          ) : (
+            <Button
+              size="md"
+              className="w-[118px]"
+              onClick={() => {
+                setOauth(!oauth);
+              }}
+            >
+              인증하기
+            </Button>
+          )}
+        </div>
+        {isAward && (
+          <LabeledInput label="수상내역" placeholder="예: 본선 진출, 3위, 장려상, 특별상 등" />
+        )}
+      </div>
+      {oauth && (
+        <div
+          className="flex w-[20px] cursor-pointer items-center justify-center rounded-md bg-gray-300"
+          onClick={onDelete}
+          role="button"
+          tabIndex={0}
+          onKeyPress={(ev) => {
+            if (ev.key === 'Enter' || ev.key === ' ') {
+              onDelete();
+            }
+          }}
+        >
+          <div className="h-[5px] w-[10px] rounded-md bg-white"></div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/features/competition/components/add-competition-modal-trigger/index.tsx
+++ b/apps/admin/src/features/competition/components/add-competition-modal-trigger/index.tsx
@@ -1,0 +1,85 @@
+'use client';
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  LabeledInput,
+} from '@hiarc-platform/ui';
+import { IconButton } from '@hiarc-platform/ui';
+import { Label } from '@hiarc-platform/ui';
+import { Button } from '@hiarc-platform/ui';
+import React from 'react';
+import { LabeledCalanderInput } from '@hiarc-platform/ui';
+import { AwardRecordForm } from './award-record-form';
+
+export function AddCompetitionModalTrigger(): React.ReactElement {
+  const [open, setOpen] = React.useState(false);
+  const [time, setTime] = React.useState<Date | null>(null);
+  const [awardForms, setAwardForms] = React.useState<number[]>([0]);
+
+  function handleAddForm(): void {
+    setAwardForms((prev) => [...prev, prev.length]);
+  }
+
+  function handleDeleteForm(id: number): void {
+    setAwardForms((prev) => prev.filter((formId) => formId !== id));
+  }
+
+  async function handleSave(): Promise<void> {
+    alert('변경이 완료되었습니다');
+    setOpen(false);
+  }
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button size="md" className="w-[100px]">
+          개설하기
+        </Button>
+      </DialogTrigger>
+      <DialogContent
+        onOpenAutoFocus={(ev) => ev.preventDefault()}
+        className="fixed left-1/2 top-1/2  !w-[540px] !max-w-[540px] -translate-x-1/2 -translate-y-1/2 overflow-visible bg-white"
+      >
+        <DialogHeader>
+          <DialogTitle className="w-full">학회원 모집 관리</DialogTitle>
+        </DialogHeader>
+        <DialogDescription className="mt-6 flex max-h-[400px] w-[482px] flex-col gap-6 overflow-y-auto">
+          <LabeledInput label="주최 단체명" placeholder="예) 현대모비스,카카오,홍익대학교" />
+          <LabeledInput label="대회명" placeholder="예) 코드 페스티벌, 알고리즘 경진대회" />
+          <LabeledCalanderInput
+            label="일시"
+            value={time}
+            placeholder="일시를 선택해주세요"
+            onChange={(val) => {
+              if (!Array.isArray(val)) {
+                setTime(val);
+              }
+            }}
+          />
+          {awardForms.map((id) => (
+            <AwardRecordForm key={id} onDelete={() => handleDeleteForm(id)} />
+          ))}
+        </DialogDescription>
+        <div className="mt-6 flex w-full items-center justify-center">
+          <IconButton
+            size="sm"
+            iconSize="lg"
+            iconSrc="/shared-assets/PlusButton.svg"
+            onClick={handleAddForm}
+          />
+        </div>
+        <div className="mt-6 flex w-full gap-2">
+          <Button variant="secondary" className="w-full" size="lg" onClick={() => setOpen(false)}>
+            <Label size="lg">취소</Label>
+          </Button>
+          <Button className="w-full" size="lg" onClick={handleSave}>
+            <Label size="lg">수정하기</Label>
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/admin/src/features/competition/components/competition-bar/competition-search-buttons.tsx
+++ b/apps/admin/src/features/competition/components/competition-bar/competition-search-buttons.tsx
@@ -1,0 +1,19 @@
+import { Button, LabeledInput } from '@hiarc-platform/ui';
+
+export function CompetitionSearchButtons(): React.ReactElement {
+  return (
+    <div className="flex w-full items-end gap-4 rounded-lg border border-gray-200 p-6 ">
+      <LabeledInput label="주최(단체명)" placeholder="Placeholder" />
+      <LabeledInput label="주최(단체명)" placeholder="Placeholder" />
+      <LabeledInput label="주최(단체명)" placeholder="Placeholder" />
+      <div className="flex gap-2">
+        <Button size="md" variant="whitebg" className="w-[134px]">
+          초기화
+        </Button>
+        <Button size="md" className="w-[134px] bg-primary-200 ">
+          검색
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/features/competition/components/competition-table/competition-list-column.tsx
+++ b/apps/admin/src/features/competition/components/competition-table/competition-list-column.tsx
@@ -152,7 +152,7 @@ export const COMPETITION_LIST_COLUMN: Array<ColumnDef<Competition>> = [
     cell: ({ row }: { row: { original: Competition } }) => (
       <IconButton
         className="relative z-10 w-full"
-        iconSrc="/Edit.svg"
+        iconSrc="/shared-assets/Edit.svg"
         size="sm"
         onClick={(event) => {
           event.stopPropagation();
@@ -178,7 +178,7 @@ export const COMPETITION_LIST_COLUMN: Array<ColumnDef<Competition>> = [
     cell: ({ row }: { row: { original: Competition } }) => (
       <IconButton
         className="relative z-10 w-full"
-        iconSrc="/Delte.svg"
+        iconSrc="/shared-assets/Delete.svg"
         size="sm"
         onClick={(event) => {
           event.stopPropagation();

--- a/apps/admin/src/features/manage/manage-tab-section/recruit-manage-section/recruit-modal/recruit-manage-modal-trigger.tsx
+++ b/apps/admin/src/features/manage/manage-tab-section/recruit-manage-section/recruit-modal/recruit-manage-modal-trigger.tsx
@@ -1,3 +1,4 @@
+'use client';
 import {
   Dialog,
   DialogTrigger,

--- a/packages/ui/src/components/select/labeled-select-button.tsx
+++ b/packages/ui/src/components/select/labeled-select-button.tsx
@@ -9,6 +9,7 @@ interface LabeledSelectButtonProps {
   required?: boolean;
   options: string[];
   className?: string;
+  onChange?(value: string): void;
 }
 
 function LabeledSelectButton({
@@ -17,8 +18,13 @@ function LabeledSelectButton({
   required = false,
   options,
   className = '',
+  onChange,
 }: LabeledSelectButtonProps): React.ReactElement {
   const [selected, setSelected] = useState<string>('');
+  const handleSelect = (option: string): void => {
+    setSelected(option);
+    onChange?.(option);
+  };
 
   return (
     <div className={cn('flex-w-full w-full flex-col', className)}>
@@ -39,7 +45,7 @@ function LabeledSelectButton({
           <Button
             key={option}
             variant={selected === option ? 'line' : 'unselected'}
-            onClick={() => setSelected(option)}
+            onClick={() => handleSelect(option)}
             className="h-11"
           >
             {option}

--- a/public/PlusButton.svg
+++ b/public/PlusButton.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="24" height="24" rx="12" fill="#D0D0DD"/>
+<path d="M12 6V18" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6 12L18 12" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## 🔀 PR 개요
<!--간단하게 PR 요약을 작성해주세요.-->
Admin/competition의 View를 구현했습니다. (modal포함)
<br/>

## 📌 주요 변경 사항
<!--주요 변경점들을 작성해주세요.-->
- Admin/competition의 View를 구현했습니다. (modal포함)
이번 작업은 거의 modal을 만드는것이 대부분의 작업이었습니다.
add-competition-modal-trigger에 modal을 trigger 하는 버튼을 구현해놓앗습니다.
그 안에서 핸들명 기록유형 수상내역은 따로 관리를 해야할것같아서 award-record-form이라는 컴포넌트로 따로 분리해주었습니다
<br/>

## 📝 작업 상세 내용
<!--작업 상세 내용을 작성해주세요.-->
Admin/competition의 View를 구현했습니다. (modal포함)
이번 작업은 거의 modal을 만드는것이 대부분의 작업이었습니다.
add-competition-modal-trigger에 modal을 trigger 하는 버튼을 구현해놓앗습니다.
그 안에서 핸들명 기록유형 수상내역은 따로 관리를 해야할것같아서 award-record-form이라는 컴포넌트로 따로 분리해주었습니다
<br/>

## 🔗 관련 이슈/PR
<!--관련 이슈나 PR이 있다면 불릿 리스트 형식으로 작성하고 없다면 없음. 을 작성해주세요-->
- #N

<br/>

## 💬 기타 참고사항
<!--기타 참고할 만한 사항들이 있다면 작성해주세요. 없다면 비워놔도 좋습니다.-->

