### PR TITLE
Refactor: 섹션 제목 및 간격 모바일 반응형 개선

### DIFF
--- a/apps/intra/src/features/main/components/hiarc-schedule-section/index.tsx
+++ b/apps/intra/src/features/main/components/hiarc-schedule-section/index.tsx
@@ -81,7 +81,10 @@ export function HiarcScheduleSection({
   return (
     <section className={cn('w-full', className)}>
       <div className="flex w-full items-center">
-        <Title size="sm" weight="bold" className="whitespace-nowrap">
+        <Title size="sm" weight="bold" className="hidden whitespace-nowrap md:block">
+          학회일정
+        </Title>
+        <Title size="xs" weight="bold" className="whitespace-nowrap md:hidden">
           학회일정
         </Title>
         <div className="ml-[14px] flex w-full items-center gap-2">

--- a/apps/intra/src/features/main/components/study-list-section/index.tsx
+++ b/apps/intra/src/features/main/components/study-list-section/index.tsx
@@ -15,7 +15,10 @@ export function StudyListSection({ className }: StudyListSectionProps): React.Re
     <div className={cn('flex w-full flex-col justify-center', className)}>
       <section className="">
         <div className="flex w-full justify-between">
-          <Title size="sm" weight="bold">
+          <Title size="sm" weight="bold" className="hidden md:block">
+            스터디목록
+          </Title>
+          <Title size="xs" weight="bold" className="md:hidden">
             스터디목록
           </Title>
           <button

--- a/apps/intra/src/features/main/pages/home/desktop-home-page.tsx
+++ b/apps/intra/src/features/main/pages/home/desktop-home-page.tsx
@@ -11,7 +11,7 @@ export function DesktopHomePage(): React.ReactElement {
       <TwoColumnLayout
         left={<HiarcScheduleSection daysToShow={7} />}
         right={<AnnouncementListSection />}
-        bottom={<StudyListSection className="mt-6" />}
+        bottom={<StudyListSection className="mt-10" />}
       />
     </ContentSection>
   );

--- a/apps/intra/src/features/main/pages/home/mobile-home-page.tsx
+++ b/apps/intra/src/features/main/pages/home/mobile-home-page.tsx
@@ -2,27 +2,17 @@
 
 import { HiarcScheduleSection } from '../../components/hiarc-schedule-section';
 import { AnnouncementListSection } from '../../components/announcement-list-section';
-import { OnboardingButton } from '../../components/onboarding-button';
 import { StudyListSection } from '../../components/study-list-section';
-import { useHomePageState } from '../../hooks/page/use-home-page-state';
-import {
-  ContentSection,
-  SingleColumnLayout,
-} from '@hiarc-platform/ui';
+import { ContentSection, SingleColumnLayout } from '@hiarc-platform/ui';
 
 export function MobileHomePage(): React.ReactElement {
-  const { isAuthenticated } = useHomePageState();
-
   return (
-    <>
-      <ContentSection>
-        <SingleColumnLayout>
-          <HiarcScheduleSection daysToShow={3} />
-          <AnnouncementListSection className="mt-6" />
-          <StudyListSection className="mt-6" />
-        </SingleColumnLayout>
-      </ContentSection>
-      {!isAuthenticated && <OnboardingButton />}
-    </>
+    <ContentSection>
+      <SingleColumnLayout>
+        <HiarcScheduleSection daysToShow={3} />
+        <AnnouncementListSection className="mt-10" />
+        <StudyListSection className="mt-10" />
+      </SingleColumnLayout>
+    </ContentSection>
   );
 }

--- a/apps/intra/src/shared/components/ui/header/mobile-header.tsx
+++ b/apps/intra/src/shared/components/ui/header/mobile-header.tsx
@@ -5,7 +5,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import useLogout from '@/features/auth/hooks/mutation/use-logout';
-import { StudyAttendanceDialog } from '@/features/study/components/study-attendance-dialog';
+// import { StudyAttendanceDialog } from '@/features/study/components/study-attendance-dialog';
 
 interface MobileHeaderProps {
   isAuthenticated: boolean;
@@ -61,7 +61,7 @@ export function MobileHeader({
             autoFocus
           />
           <IconButton
-            iconSrc="/Close.svg"
+            iconSrc="/shared-assets/Close.svg"
             aria-label="검색 닫기"
             onClick={() => setIsMobileSearchOpen(false)}
           />
@@ -74,10 +74,11 @@ export function MobileHeader({
           )}
         >
           <Link href="/">
-            <Image src="/shared-assets/Logo.svg" alt="HiarcLogo" width={120} height={30} />
+            <Image src="/shared-assets/Logo.svg" alt="HiarcLogo" width={86} height={21} />
           </Link>
           <div className="flex items-center gap-2">
             <IconButton
+              size="lg"
               iconSrc="/shared-assets/ZoomIn.svg"
               aria-label="검색"
               onClick={() => setIsMobileSearchOpen(true)}
@@ -85,22 +86,25 @@ export function MobileHeader({
             {isAuthenticated ? (
               <div className="flex items-center gap-2">
                 <IconButton
+                  size="lg"
                   iconSrc="/shared-assets/User.svg"
                   aria-label="프로필"
                   onClick={handleMyPage}
                 />
-                <Button
-                  size="sm"
+                {/* 2025.08.24
+                출석체크 버튼 임시 비활성화 */}
+                {/* <Button
+                  size="xs"
                   className="bg-primary-100"
                   onClick={() => {
                     DialogUtil.showComponent(<StudyAttendanceDialog />);
                   }}
                 >
                   출석체크
-                </Button>
+                </Button> */}
                 <Button
-                  variant="secondary"
-                  size="sm"
+                  variant="line_secondary"
+                  size="xs"
                   onClick={handleLogout}
                   disabled={logoutMutation.isPending}
                 >
@@ -108,7 +112,7 @@ export function MobileHeader({
                 </Button>
               </div>
             ) : (
-              <Button variant="secondary" size="sm" onClick={handleLogin}>
+              <Button variant="line_secondary" size="xs" onClick={handleLogin}>
                 로그인
               </Button>
             )}

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -27,7 +27,10 @@ export function Tabs({ tabs, activeTab, onTabClick, className = '' }: TabsProps)
             onClick={() => onTabClick?.(tab.value)}
             type="button"
           >
-            <Title size="sm" weight="bold" className="cursor-pointer select-none">
+            <Title size="sm" weight="bold" className="hidden cursor-pointer select-none md:block">
+              {tab.label}
+            </Title>
+            <Title size="xs" weight="bold" className="cursor-pointer select-none md:hidden">
               {tab.label}
             </Title>
           </button>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -28,6 +28,7 @@ module.exports = {
     'h-[46.5px]',
     'h-[10px]',
     'h-15',
+    'md:text-xs',
     'rounded-xl',
     'gap-[3px]',
     'accent-primary-100',


### PR DESCRIPTION
## 🔀 PR 개요
모바일 환경에 대한 UI 반응성과 시각적 일관성을 개선
헤더와 섹션 제목을 중심으로 몇 가지 사소한 스타일 조정을 적용
스터디 출석 버튼을 일시적으로 비활성화하고 에셋 경로를 업데이트

<br/>

## 📌 주요 변경 사항
- **UI 반응성 및 일관성 개선**: 헤더와 섹션 제목의 텍스트 크기를 데스크톱과 모바일 환경에 맞춰 조정하고, 섹션별 여백을 통일
- **헤더 및 에셋 업데이트**: 모바일 헤더의 로고와 아이콘 에셋 경로를 변경, 버튼 스타일을 모바일에 최적화된 새로운 형태로 수정
- **기능 조정**: 스터디 출석 버튼을 임시로 비활성화

<br/>

## 📝 작업 상세 내용
### UI 반응성 및 일관성
- `HiarcScheduleSection`, `StudyListSection`, `Tabs` 컴포넌트의 섹션 제목 텍스트 크기를 조정하여 데스크톱(큰 텍스트)과 모바일(작은 텍스트)에서 모두 가독성을 높임
- `StudyListSection`과 `AnnouncementListSection` 컴포넌트의 여백을 데스크톱과 모바일 홈 페이지에 맞게 조정하여 레이아웃의 일관성을 확보

### 헤더 및 에셋 업데이트
- `MobileHeader`에서 로고와 아이콘 에셋 경로 및 크기를 변경하여 시각적 적합성과 유지보수성을 개선
- `MobileHeader`의 버튼 스타일을 새로운 variants(`line_secondary`) 및 작은 사이즈(`xs`)로 업데이트하여 모바일 환경에 더 적합하게 변경

### 기능 조정
- 모바일 헤더에서 스터디 출석 버튼을 임시로 비활성화하고, 관련 import 코드를 주석 처리, 이는 향후 업데이트나 문제 해결을 위한 임시 조치

<br/>

## 🔗 관련 이슈/PR
- 없음

<br/>

## 💬 기타 참고사항
없음.