### PR TITLE
feat: 모집 시작 API에 시작일 및 종료일 추가

### DIFF
--- a/apps/admin/src/features/member/components/manage-tab-section/recruit-manage-section/recruit-modal/recruit-start-dialog.tsx
+++ b/apps/admin/src/features/member/components/manage-tab-section/recruit-manage-section/recruit-modal/recruit-start-dialog.tsx
@@ -1,9 +1,7 @@
 'use client';
 
 import { useStartRecruitment } from '@/features/recruitment/hooks/mutation/use-start-recruitment';
-import { useUpdateRecruitment } from '@/features/recruitment/hooks/mutation/use-update-recruitment';
 import { useSelectedSemester } from '@/shared/hooks/use-semester-store';
-import { UpdateRecruitmentRequest } from '@hiarc-platform/shared';
 import {
   Dialog,
   DialogContent,
@@ -36,7 +34,13 @@ export function RecruitStartDialog({
   const handleStartRecruit = async (): Promise<void> => {
     try {
       if (startDate && endDate) {
-        startRecruitment(Number(selectedSemesterId));
+        startRecruitment({
+          semesterId: Number(selectedSemesterId),
+          data: {
+            startDate: startDate.toISOString().split('T')[0],
+            endDate: endDate.toISOString().split('T')[0],
+          },
+        });
 
         DialogUtil.hideAllDialogs();
       } else {

--- a/apps/admin/src/features/recruitment/api/recruitment.ts
+++ b/apps/admin/src/features/recruitment/api/recruitment.ts
@@ -2,6 +2,7 @@ import { apiClient } from '@/shared/api/client';
 import {
   PageableModel,
   Recruitment,
+  StartRecruitmentRequest,
   StudentApply,
   UpdateRecruitmentRequest,
 } from '@hiarc-platform/shared';
@@ -39,8 +40,8 @@ export const recruitmentApi = {
    * @param semesterId - 모집을 시작할 학기의 ID입니다.
    * @returns void
    */
-  START_RECRUITMENT: async (semesterId: number): Promise<void> => {
-    await apiClient.post<void>(`/admin/recruitment/${semesterId}`);
+  START_RECRUITMENT: async (semesterId: number, data: StartRecruitmentRequest): Promise<void> => {
+    await apiClient.post<void>(`/admin/recruitment/${semesterId}`, data);
   },
 
   /**

--- a/apps/admin/src/features/recruitment/hooks/mutation/use-start-recruitment.ts
+++ b/apps/admin/src/features/recruitment/hooks/mutation/use-start-recruitment.ts
@@ -1,12 +1,19 @@
 import { useMutation, UseMutationResult, useQueryClient } from '@tanstack/react-query';
 import { DialogUtil } from '@hiarc-platform/ui';
+import { StartRecruitmentRequest } from '@hiarc-platform/shared';
 import { recruitmentApi } from '../../api';
 
-export function useStartRecruitment(): UseMutationResult<void, Error, number, unknown> {
+interface StartRecruitmentParams {
+  semesterId: number;
+  data: StartRecruitmentRequest;
+}
+
+export function useStartRecruitment(): UseMutationResult<void, Error, StartRecruitmentParams, unknown> {
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
-    mutationFn: (semesterId: number) => recruitmentApi.START_RECRUITMENT(semesterId),
+    mutationFn: ({ semesterId, data }: StartRecruitmentParams) => 
+      recruitmentApi.START_RECRUITMENT(semesterId, data),
     onSuccess: (_) => {
       queryClient.invalidateQueries({ queryKey: ['recruitment-list'] });
       DialogUtil.showSuccess('모집이 성공적으로 시작되었습니다.');

--- a/packages/shared/src/types/recruit/update-recruitment-request.ts
+++ b/packages/shared/src/types/recruit/update-recruitment-request.ts
@@ -5,3 +5,8 @@ export interface UpdateRecruitmentRequest {
   militaryDescription?: string;
   greetingDescription?: string;
 }
+
+export interface StartRecruitmentRequest {
+  startDate?: string;
+  endDate?: string;
+}


### PR DESCRIPTION
## 🔀 PR 개요
<!--간단하게 PR 요약을 작성해주세요.-->
StartRecruitmentRequest 도입으로 시작일 및 종료일을 받도록 모집 시작 플로우 업데이트
모집 시작 시 해당 날짜들을 전달하도록 API, 훅, 다이얼로그 수정
<br/>

## 📌 주요 변경 사항
<!--주요 변경점들을 작성해주세요.-->
- StartRecruitmentRequest 도입으로 시작일 및 종료일을 받도록 모집 시작 플로우 업데이트
- 모집 시작 시 해당 날짜들을 전달하도록 API, 훅, 다이얼로그 수정
- ...

<br/>

## 📝 작업 상세 내용
<!--작업 상세 내용을 작성해주세요.-->
StartRecruitmentRequest 도입으로 시작일 및 종료일을 받도록 모집 시작 플로우 업데이트
모집 시작 시 해당 날짜들을 전달하도록 API, 훅, 다이얼로그 수정
<br/>

## 🔗 관련 이슈/PR
<!--관련 이슈나 PR이 있다면 불릿 리스트 형식으로 작성하고 없다면 없음. 을 작성해주세요-->

<br/>

## 💬 기타 참고사항
<!--기타 참고할 만한 사항들이 있다면 작성해주세요. 없다면 비워놔도 좋습니다.-->

