### PR TITLE
Feat: 스터디를 받는 시간이 미국시간->한국 시간으로 변경, CreateStudyMember에서 response.data가 배열이 아닐때의 문제해결

### DIFF
--- a/apps/admin/src/features/study/api/study.ts
+++ b/apps/admin/src/features/study/api/study.ts
@@ -139,6 +139,12 @@ export const studyApi = {
   GET_STUDY_MEMBERS: async (studyId: number): Promise<StudyMember[]> => {
     try {
       const response = await apiClient.get(`/studies/${studyId}/instructor/status`);
+
+      // response.data가 배열인지 확인
+      if (!Array.isArray(response.data)) {
+        return [];
+      }
+
       return response.data.map((member: unknown) => StudyMember.fromJson(member));
     } catch (error) {
       console.error('[STUDY API] GET_STUDY_MEMBERS 에러:', error);

--- a/apps/admin/src/features/study/components/create-study-form-section/create-study-form.tsx
+++ b/apps/admin/src/features/study/components/create-study-form-section/create-study-form.tsx
@@ -147,16 +147,24 @@ export function CreateStudyForm({
       bojHandle: formData.bojHandle,
       isGroupStudy: formData.isGroupStudy,
       semesterId: formData.semesterId,
-      startDate: studyPeriod[0]?.toISOString().split('T')[0] || null,
-      endDate: studyPeriod[1]?.toISOString().split('T')[0] || null,
+      startDate: studyPeriod[0]
+        ? new Date(studyPeriod[0].getTime() + 9 * 60 * 60 * 1000).toISOString().split('T')[0]
+        : null,
+      endDate: studyPeriod[1]
+        ? new Date(studyPeriod[1].getTime() + 9 * 60 * 60 * 1000).toISOString().split('T')[0]
+        : null,
       scheduledDays: selectedDays.length > 0 ? selectedDays : null,
       startTime: selectedStartTime ? normalizeTimeFormat(selectedStartTime) : null,
       isOnline: isOnline === 'ONLINE' ? true : isOnline === 'IN_PERSON' ? false : null,
       isPublic: isPublic === 'PUBLIC' ? true : isPublic === 'PRIVATE' ? false : null,
       lang: formData.lang,
       introduction: formData.introduction,
-      recruitmentStartAt: cruitPeriod[0]?.toISOString().split('T')[0] || null,
-      recruitmentEndAt: cruitPeriod[1]?.toISOString().split('T')[0] || null,
+      recruitmentStartAt: cruitPeriod[0]
+        ? new Date(cruitPeriod[0].getTime() + 9 * 60 * 60 * 1000).toISOString().split('T')[0]
+        : null,
+      recruitmentEndAt: cruitPeriod[1]
+        ? new Date(cruitPeriod[1].getTime() + 9 * 60 * 60 * 1000).toISOString().split('T')[0]
+        : null,
       precaution: formData.precaution,
     };
 


### PR DESCRIPTION
…가 배열이 아닐때 빈 배열 반환하게 바꾸기

## 🔀 PR 개요
<!--간단하게 PR 요약을 작성해주세요.-->
스터디를 받는 시간이 미국시간->한국 시간으로 변경 (+9시간)
 CreateStudyMember에서 response.data가 배열이 아닐때의 문제해결
<br/>

## 📌 주요 변경 사항
<!--주요 변경점들을 작성해주세요.-->
- 스터디를 받는 시간이 미국시간->한국 시간으로 변경 (+9시간)
-  CreateStudyMember에서 response.data가 배열이 아닐때의 문제해결
- ...

<br/>

## 📝 작업 상세 내용
<!--작업 상세 내용을 작성해주세요.-->
스터디 시간을 받을 때, startDate: studyPeriod[0]?.toISOString().split('T')[0] || null 로 받게 되면 UTC시간 기준으로 되기때문에 한국보다 9시간이 느립니다. 그래서 한국 시간 기준으로 +9시간을 했습니다.

<img width="872" height="278" alt="image" src="https://github.com/user-attachments/assets/2738aefe-2b85-4102-a1ba-1a56cf98979e" />

현재 백엔드에서 studyGroup과 aloneStudents를 구분하는 로직을 만들고 이게. 배열로 오고있지 않아 오류가 발생 해서
일단 이럴 경우 빈 배열을 반환하게끔 했습니다
<br/>

## 🔗 관련 이슈/PR
<!--관련 이슈나 PR이 있다면 불릿 리스트 형식으로 작성하고 없다면 없음. 을 작성해주세요-->
- #N

<br/>

## 💬 기타 참고사항
<!--기타 참고할 만한 사항들이 있다면 작성해주세요. 없다면 비워놔도 좋습니다.-->

