### PR TITLE
Feat: 학회원 검색 기능 연결 Task/91

### DIFF
--- a/apps/intra/src/app/member/[id]/page.tsx
+++ b/apps/intra/src/app/member/[id]/page.tsx
@@ -1,3 +1,36 @@
+'use client';
+
+import { useMemberProfile } from '@/features/member/hooks/query/use-member-profile';
+import {
+  DesktopMemberDetailPage,
+  MobileMemberDetailPage,
+} from '@/features/member/pages/member-detail-page';
+import { PageLayout } from '@hiarc-platform/ui';
+import { useParams, useRouter } from 'next/navigation';
+
 export default function MemberProfilePage(): React.ReactElement {
-  return <div>Member Profile Page</div>;
+  const params = useParams();
+  const id = params.id as string;
+  const { data, isLoading, error } = useMemberProfile(Number(id));
+  const router = useRouter();
+
+  const handleBackClick = (): void => {
+    router.back();
+  };
+
+  return (
+    <PageLayout
+      desktopChildren={
+        <DesktopMemberDetailPage
+          memberProfileData={data}
+          isLoading={isLoading}
+          error={error}
+          onBackClick={handleBackClick}
+        />
+      }
+      mobileChildren={
+        <MobileMemberDetailPage memberProfileData={data} isLoading={isLoading} error={error} />
+      }
+    />
+  );
 }

--- a/apps/intra/src/features/award/components/award-section/index.tsx
+++ b/apps/intra/src/features/award/components/award-section/index.tsx
@@ -35,7 +35,9 @@ export function AwardSection({
       </div>
 
       {!awardList || awardList.length === 0 ? (
-        <Label className="py-20 text-center">대회 정보가 없어요</Label>
+        <Label className="py-20 text-center" size="lg">
+          대회 정보가 없어요.
+        </Label>
       ) : (
         awardList.map((award) => <AwardListItem key={award.awardId} award={award} />)
       )}

--- a/apps/intra/src/features/member/api/member.ts
+++ b/apps/intra/src/features/member/api/member.ts
@@ -37,7 +37,7 @@ export const myApi = {
    * @returns 회원 ID를 반환합니다.
    */
   GET_MEMBER_ID_BY_HANDLE: async (bojHandle: string): Promise<number> => {
-    const response = await apiClient.get('/members/me/handle', {
+    const response = await apiClient.get('/members/search', {
       params: {
         bojHandle,
       },

--- a/apps/intra/src/features/member/components/hiting-section/index.tsx
+++ b/apps/intra/src/features/member/components/hiting-section/index.tsx
@@ -10,6 +10,7 @@ interface HitingSectionProps {
   today: number;
   ratingRecords?: RatingRecord[];
   className?: string;
+  isMe?: boolean;
 }
 
 export function HitingSection({
@@ -18,6 +19,7 @@ export function HitingSection({
   today,
   ratingRecords,
   className,
+  isMe = true,
 }: HitingSectionProps): React.ReactElement {
   return (
     <div className={`flex w-full flex-col gap-4 ${className}`}>
@@ -42,18 +44,20 @@ export function HitingSection({
             ))}
           </div>
         ) : (
-          <div className="flexl justify-center">
+          <div className="flex justify-center">
             <Label size="lg" weight="regular" className="text-gray-700">
-              하이팅에 참여하시고, 10위 안에 도전해보세요!
+              {isMe ? '하이팅에 참여하시고, 10위 안에 도전해보세요!' : '하이팅 참여 기록이 없어요.'}
             </Label>
-            <Label
-              size="lg"
-              weight="regular"
-              className="ml-2 cursor-pointer text-gray-700 underline"
-              onClick={() => window.open('https://rating.hiarc-official.com', '_blank')}
-            >
-              하이팅 바로가기
-            </Label>
+            {isMe && (
+              <Label
+                size="lg"
+                weight="regular"
+                className="ml-2 cursor-pointer text-gray-700 underline"
+                onClick={() => window.open('https://rating.hiarc-official.com', '_blank')}
+              >
+                하이팅 바로가기
+              </Label>
+            )}
           </div>
         )}
       </SectionContainer>

--- a/apps/intra/src/features/member/hooks/query/use-member-profile.ts
+++ b/apps/intra/src/features/member/hooks/query/use-member-profile.ts
@@ -2,7 +2,7 @@ import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import { myApi } from '../../api/member';
 import { MemberProfile } from '../../types/model/member-profile';
 
-export function useMyProfileData(memberId: number): UseQueryResult<MemberProfile, Error> {
+export function useMemberProfile(memberId: number): UseQueryResult<MemberProfile, Error> {
   return useQuery({
     queryKey: ['member', memberId],
     queryFn: () => myApi.GET_MEMBER_PROFILE(memberId),

--- a/apps/intra/src/features/member/pages/member-detail-page/desktop-member-detail-page.tsx
+++ b/apps/intra/src/features/member/pages/member-detail-page/desktop-member-detail-page.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { AwardSection } from '@/features/award/components/award-section';
+import { HitingSection } from '@/features/member/components/hiting-section';
+import { MyInfoSection } from '@/features/member/components/my-info-section';
+import { StreakSection } from '@/features/member/components/streak-section';
+import { BackButton, Divider, TwoColumnLayout, LoadingDots, FadeIn } from '@hiarc-platform/ui';
+import { MemberProfile } from '../../types/model/member-profile';
+
+interface DesktopMemberDetailPageProps {
+  memberProfileData?: MemberProfile;
+  isLoading: boolean;
+  error: Error | null;
+  onBackClick?(): void;
+}
+
+export function DesktopMemberDetailPage({
+  memberProfileData,
+  isLoading,
+  error,
+  onBackClick,
+}: DesktopMemberDetailPageProps): React.ReactElement {
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <LoadingDots />
+      </div>
+    );
+  }
+
+  if (error !== null) {
+    return <div>Error loading member profile</div>;
+  }
+
+  if (!memberProfileData) {
+    return <div>Error loading member profile</div>;
+  }
+
+  return (
+    <FadeIn isVisible={isLoading || error ? false : true}>
+      <BackButton onClick={onBackClick} />
+      <MyInfoSection
+        className="mt-5"
+        isMe={false}
+        bojHandle={memberProfileData.bojHandle}
+        name={memberProfileData.name}
+        introduction={memberProfileData.introduction}
+        rating={memberProfileData.tier ?? 'UNRATED'}
+        div={memberProfileData.division ?? 'UNRATED'}
+      />
+      <Divider variant="horizontal" size="full" className="mt-4 bg-gray-900" />
+      <TwoColumnLayout
+        className="mt-8"
+        left={
+          <>
+            <HitingSection
+              isMe={false}
+              season={memberProfileData.rating?.seasonScore ?? 0}
+              total={memberProfileData.rating?.totalScore ?? 0}
+              today={memberProfileData.rating?.todayScore ?? 0}
+            />
+            <StreakSection className="mt-6" />
+          </>
+        }
+        right={<AwardSection awardList={memberProfileData.award ?? []} />}
+      />
+    </FadeIn>
+  );
+}

--- a/apps/intra/src/features/member/pages/member-detail-page/index.ts
+++ b/apps/intra/src/features/member/pages/member-detail-page/index.ts
@@ -1,0 +1,2 @@
+export { DesktopMemberDetailPage } from './desktop-member-detail-page';
+export { MobileMemberDetailPage } from './mobile-member-detail-page';

--- a/apps/intra/src/features/member/pages/member-detail-page/mobile-member-detail-page.tsx
+++ b/apps/intra/src/features/member/pages/member-detail-page/mobile-member-detail-page.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { AwardSection } from '@/features/award/components/award-section';
+import { HitingSection } from '@/features/member/components/hiting-section';
+import { MyInfoSection } from '@/features/member/components/my-info-section';
+import { StreakSection } from '@/features/member/components/streak-section';
+import { Divider, LoadingDots, FadeIn } from '@hiarc-platform/ui';
+import { MemberProfile } from '../../types/model/member-profile';
+
+interface MobileMemberDetailPageProps {
+  memberProfileData?: MemberProfile;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export function MobileMemberDetailPage({
+  memberProfileData,
+  isLoading,
+  error,
+}: MobileMemberDetailPageProps): React.ReactElement {
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <LoadingDots />
+      </div>
+    );
+  }
+
+  if (error !== null) {
+    return <div>Error loading member profile</div>;
+  }
+
+  if (!memberProfileData) {
+    return <div>No member profile data available</div>;
+  }
+
+  return (
+    <FadeIn isVisible={!isLoading && !error}>
+      <MyInfoSection
+        className="mt-5"
+        isMe={false}
+        bojHandle={memberProfileData?.bojHandle}
+        name={memberProfileData?.name}
+        introduction={memberProfileData?.introduction}
+        rating={memberProfileData?.tier ?? 'UNRATED'}
+        div={memberProfileData?.division ?? 'UNRATED'}
+      />
+      <Divider variant="horizontal" size="full" className="mt-4 bg-gray-900" />
+      <HitingSection
+        className="mt-6"
+        isMe={false}
+        season={memberProfileData?.rating?.seasonScore ?? 0}
+        total={memberProfileData?.rating?.totalScore ?? 0}
+        today={memberProfileData?.rating?.todayScore ?? 0}
+      />
+      <StreakSection className="mt-4" />
+      <AwardSection className="mt-4" awardList={memberProfileData?.award ?? []} />
+    </FadeIn>
+  );
+}

--- a/apps/intra/src/shared/components/ui/ConditionalHeaderClient.tsx
+++ b/apps/intra/src/shared/components/ui/ConditionalHeaderClient.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import { MobileHeader as UIMobileHeader, MenuItem } from '@hiarc-platform/ui';
 import { MobileHeader } from './header/mobile-header';
@@ -12,6 +13,7 @@ interface ConditionalHeaderClientProps {
 export function ConditionalHeaderClient({
   isAuthenticated,
 }: ConditionalHeaderClientProps): React.ReactElement {
+  const [searchInput, setSearchInput] = useState('');
   const pathname = usePathname();
   const router = useRouter();
   const isAnnouncementList = pathname === '/announcement';
@@ -83,8 +85,16 @@ export function ConditionalHeaderClient({
         <div className="hidden md:block">
           <header className="flex w-full items-center justify-between border-b border-gray-200">
             <div className="mx-auto flex w-full max-w-[1200px] items-center justify-between px-5 py-4">
-              <MobileHeader isAuthenticated={isAuthenticated} />
-              <DesktopHeader isAuthenticated={isAuthenticated} />
+              <MobileHeader 
+                isAuthenticated={isAuthenticated}
+                searchInput={searchInput}
+                setSearchInput={setSearchInput}
+              />
+              <DesktopHeader 
+                isAuthenticated={isAuthenticated}
+                searchInput={searchInput}
+                setSearchInput={setSearchInput}
+              />
             </div>
           </header>
         </div>
@@ -96,8 +106,16 @@ export function ConditionalHeaderClient({
   return (
     <header className="flex w-full items-center justify-between border-b border-gray-200">
       <div className="mx-auto flex w-full max-w-[1200px] items-center justify-between px-5 py-4">
-        <MobileHeader isAuthenticated={isAuthenticated} />
-        <DesktopHeader isAuthenticated={isAuthenticated} />
+        <MobileHeader 
+          isAuthenticated={isAuthenticated}
+          searchInput={searchInput}
+          setSearchInput={setSearchInput}
+        />
+        <DesktopHeader 
+          isAuthenticated={isAuthenticated}
+          searchInput={searchInput}
+          setSearchInput={setSearchInput}
+        />
       </div>
     </header>
   );

--- a/apps/intra/src/shared/components/ui/header/desktop-header.tsx
+++ b/apps/intra/src/shared/components/ui/header/desktop-header.tsx
@@ -1,21 +1,69 @@
 'use client';
 
-import { Button, Input, Label } from '@hiarc-platform/ui';
+import {
+  Button,
+  Input,
+  Label,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@hiarc-platform/ui';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter, usePathname } from 'next/navigation';
+import { useState } from 'react';
 import { AuthenticatedUserSection } from './authenticated-user-section';
+import { myApi } from '@/features/member/api/member';
 
 interface DesktopHeaderProps {
   isAuthenticated: boolean;
+  searchInput: string;
+  setSearchInput(value: string): void;
 }
 
-export function DesktopHeader({ isAuthenticated }: DesktopHeaderProps): React.ReactElement {
+export function DesktopHeader({
+  isAuthenticated,
+  searchInput,
+  setSearchInput,
+}: DesktopHeaderProps): React.ReactElement {
+  const [showError, setShowError] = useState(false);
   const router = useRouter();
   const pathname = usePathname();
+  const [isFetching, setIsFetching] = useState(false);
 
   const handleLogin = (): void => {
     router.push('/login');
+  };
+
+  const handleSearch = async (handle: string): Promise<void> => {
+    if (!handle.trim()) {
+      return;
+    }
+
+    setShowError(false);
+
+    setIsFetching(true);
+
+    try {
+      const memberId = await myApi.GET_MEMBER_ID_BY_HANDLE(handle);
+      if (memberId) {
+        router.push(`/member/${memberId}`);
+        setSearchInput('');
+      } else {
+        setShowError(true);
+      }
+    } catch (error) {
+      setShowError(true);
+    } finally {
+      setIsFetching(false);
+    }
+  };
+
+  const closeError = (): void => {
+    setShowError(false);
   };
 
   const isActive = (path: string): boolean => pathname.startsWith(`/${path}`);
@@ -72,11 +120,18 @@ export function DesktopHeader({ isAuthenticated }: DesktopHeaderProps): React.Re
       </div>
       <div className="flex items-center gap-2">
         <Input
-          disabled
           type="search"
           variant="search"
-          placeholder="모집 종료 후 검색 기능이 제공될 예정입니다."
+          placeholder={isAuthenticated ? 'BOJ 핸들명을 입력하세요' : '로그인 후 검색 가능합니다'}
           className="h-[44px] w-[328px]"
+          value={searchInput}
+          onChange={(event) => setSearchInput(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' && isAuthenticated) {
+              handleSearch(searchInput);
+            }
+          }}
+          disabled={!isAuthenticated || isFetching}
         />
         {isAuthenticated ? (
           <AuthenticatedUserSection />
@@ -86,6 +141,18 @@ export function DesktopHeader({ isAuthenticated }: DesktopHeaderProps): React.Re
           </Button>
         )}
       </div>
+
+      <Dialog open={showError} onOpenChange={closeError}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>검색 실패</DialogTitle>
+            <DialogDescription>해당 BOJ 핸들명을 가진 회원을 찾을 수 없습니다.</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button onClick={closeError}>확인</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/apps/intra/src/shared/components/ui/header/index.tsx
+++ b/apps/intra/src/shared/components/ui/header/index.tsx
@@ -1,15 +1,27 @@
+'use client';
+
+import { useState } from 'react';
 import { ServerCookieUtil } from '@/shared/utils/server-cookie-util';
 import { MobileHeader } from './mobile-header';
 import { DesktopHeader } from './desktop-header';
 
 export default function Header(): React.ReactElement {
   const { isAuthenticated } = ServerCookieUtil.checkAuth();
+  const [searchInput, setSearchInput] = useState('');
 
   return (
     <header className="flex w-full items-center justify-between border-b border-gray-200">
       <div className="mx-auto flex w-full max-w-[1200px] items-center justify-between px-5 py-4">
-        <MobileHeader isAuthenticated={isAuthenticated} />
-        <DesktopHeader isAuthenticated={isAuthenticated} />
+        <MobileHeader
+          isAuthenticated={isAuthenticated}
+          searchInput={searchInput}
+          setSearchInput={setSearchInput}
+        />
+        <DesktopHeader
+          isAuthenticated={isAuthenticated}
+          searchInput={searchInput}
+          setSearchInput={setSearchInput}
+        />
       </div>
     </header>
   );


### PR DESCRIPTION
## 🔀 PR 개요
회원 프로필 조회, 스터디 생성/편집, 헤더 검색 기능 강화를 중심으로 여러 새로운 기능과 개선사항을 도입
데스크톱과 모바일용 상세 회원 프로필 페이지 구현, 스터디 폼의 그룹 스터디 옵션 추가, 헤더의 새로운 BOJ 핸들 검색 기능이 주요 변경사항

<br/>

## 📌 주요 변경 사항
- 데스크톱과 모바일용 완전한 회원 프로필 페이지 구현
- 스터디 생성 및 편집 폼에 그룹 스터디 옵션 추가
- 헤더에 BOJ 핸들 검색 기능 구현으로 회원 검색 및 프로필 직접 이동 지원
- 시상 및 히팅 섹션의 빈 상태 메시징 및 스타일링 개선
- 코드 정리 및 유지보수성 향상을 위한 리팩토링 작업

<br/>

## 📝 작업 상세 내용
**회원 프로필 페이지 구현**
- 시상, 히팅, 연속 기록, 개인 정보 섹션을 포함한 데스크톱과 모바일용 완전한 회원 프로필 페이지 추가, 로딩 및 에러 처리 포함
- 더 명확한 이름 사용을 위해 회원 프로필 쿼리 훅을 `useMemberProfile`로 리팩토링
- BOJ 핸들로 회원 ID 검색을 위한 API 엔드포인트 업데이트

**스터디 생성 및 편집 개선사항**
- 생성 및 편집 스터디 폼과 요청 타입 모두에 `isGroupStudy` 필드 추가하여 UI와 API 전반에 걸쳐 그룹 스터디 상태 적절히 처리
- 컨텍스트 및 사용성 개선을 위해 강의용 출석 다이얼로그 래퍼에 추가 props 전달

**헤더 검색 기능**
- 데스크톱과 모바일 헤더 모두에 BOJ 핸들 검색 입력 기능 구현, 인증된 사용자가 회원을 검색하고 프로필 페이지로 직접 이동 가능
- 에러 처리 포함 및 인증되지 않은 경우 검색 비활성화

**UI 개선사항**
- 사용자 컨텍스트에 따른 조건부 메시지를 포함하여 시상 및 히팅 섹션의 빈 상태 메시징 및 스타일링 개선

**리팩토링 및 코드 품질**
- 오타 수정, prop 전달 개선, 유지보수성을 위한 데스크톱/모바일 로직 분리 등 일반적인 코드 정리 작업

<br/>

## 🔗 관련 이슈/PR
- #91 

<br/>

## 💬 기타 참고사항
없음