### PR TITLE
Fix: 스터디 커리큘럼 목록 역할 별 방어 처리, 모바일 뷰 수정

### DIFF
--- a/apps/intra/src/features/announcement/hooks/mutation/use-update-instructor-announcement.ts
+++ b/apps/intra/src/features/announcement/hooks/mutation/use-update-instructor-announcement.ts
@@ -2,9 +2,11 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { DialogUtil } from '@hiarc-platform/ui';
 import { UpdateAnnouncementRequest } from '../../types/request/update-announcement-request';
 import { announcementApi } from '../../api/announcement';
+import { useRouter } from 'next/navigation';
 
 export const useUpdateInstructorAnnouncement = () => {
   const queryClient = useQueryClient();
+  const router = useRouter();
 
   return useMutation({
     mutationFn: ({
@@ -20,7 +22,9 @@ export const useUpdateInstructorAnnouncement = () => {
       queryClient.invalidateQueries({ queryKey: ['announcements'] });
       queryClient.invalidateQueries({ queryKey: ['announcement', announcementId.toString()] });
       queryClient.invalidateQueries({ queryKey: ['study', studyId] });
-      DialogUtil.showSuccess('공지사항이 성공적으로 업데이트되었습니다.');
+      DialogUtil.showSuccess('공지사항이 성공적으로 업데이트되었습니다.', () => {
+        router.back();
+      });
     },
   });
 };

--- a/apps/intra/src/features/announcement/pages/announcement-write/desktop-announcement-write-page.tsx
+++ b/apps/intra/src/features/announcement/pages/announcement-write/desktop-announcement-write-page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { AnnouncementDesktopHeader, BackButton, Divider } from '@hiarc-platform/ui';
-import { Title } from '@hiarc-platform/ui';
+import { AnnouncementDesktopHeader } from '@hiarc-platform/ui';
 import { AnnouncementWrite } from '@hiarc-platform/ui';
 import { useAnnouncementWritePageState } from '../../hooks/page/use-announcement-write-page-state';
 

--- a/apps/intra/src/features/study/hooks/page/use-study-detail-page-state.ts
+++ b/apps/intra/src/features/study/hooks/page/use-study-detail-page-state.ts
@@ -22,22 +22,11 @@ export function useStudyDetailPageState() {
   };
 
   const handleApplyClick = (): void => {
-    DialogUtil.showCustom(
-      React.createElement(
-        'div',
-        null,
-        '기초/초급 스터디는 동일 시간에 진행되어 중복 신청이 불가합니다.',
-        React.createElement('br', null),
-        React.createElement('br', null),
-        '신청을 완료하시겠습니까?'
-      ),
-      {
-        title: '유의사항',
-        size: 'md',
-        onConfirm: () => applyToStudy(studyId),
-        confirmText: '신청하기',
-        cancelText: '취소',
-      }
+    DialogUtil.showConfirm(
+      '기초/초급 스터디는 동일 시간에 진행되어 중복 신청이 불가합니다.',
+      () => applyToStudy(studyId),
+      undefined,
+      { title: '유의사항' }
     );
   };
 

--- a/apps/intra/src/features/study/hooks/study-instructor/mutation/use-create-study-announcement.ts
+++ b/apps/intra/src/features/study/hooks/study-instructor/mutation/use-create-study-announcement.ts
@@ -3,6 +3,8 @@ import { useMutation, UseMutationResult, useQueryClient } from '@tanstack/react-
 import { Announcement } from '@hiarc-platform/shared';
 import { CreateAnnouncementRequest } from '@hiarc-platform/shared';
 import { announcementApi } from '@/features/announcement/api/announcement';
+import { DialogUtil } from '@hiarc-platform/ui';
+import { useRouter } from 'next/navigation';
 
 interface CreateStudyAnnouncementParams {
   studyId: number;
@@ -18,6 +20,7 @@ export default function useCreateStudyAnnouncement(): UseMutationResult<
   unknown
 > {
   const queryClient = useQueryClient();
+  const router = useRouter();
 
   const mutation = useMutation({
     mutationFn: (data: MutationInput) => {
@@ -28,15 +31,13 @@ export default function useCreateStudyAnnouncement(): UseMutationResult<
       }
     },
     onSuccess: (newAnnouncement, variables) => {
-      console.log('[HOOK] useCreateStudyAnnouncement 성공:', newAnnouncement);
-
       if ('studyId' in variables && 'announcementData' in variables) {
         queryClient.invalidateQueries({ queryKey: ['studies', { studyId: variables.studyId }] });
       }
       queryClient.invalidateQueries({ queryKey: ['announcements'] });
-    },
-    onError: (error) => {
-      console.error('[HOOK] useCreateStudyAnnouncement 에러:', error);
+      DialogUtil.showSuccess('공지사항이 성공적으로 생성되었습니다.', () => {
+        router.back();
+      });
     },
   });
 

--- a/apps/intra/src/features/study/pages/study-detail/mobile-study-detail-page.tsx
+++ b/apps/intra/src/features/study/pages/study-detail/mobile-study-detail-page.tsx
@@ -25,7 +25,7 @@ export function MobileStudyDetailPage(): React.ReactElement {
   }
 
   return (
-    <div className="flex flex-col pt-10">
+    <div className="flex flex-col pt-10 pb-20 md:pb-0">
       <StudyInfoSection
         className="pt-4"
         studyData={studyData}

--- a/packages/ui/src/components/dialogs/confirm-dialog.tsx
+++ b/packages/ui/src/components/dialogs/confirm-dialog.tsx
@@ -44,10 +44,10 @@ export function ConfirmDialog({
         showBackground={showBackground ?? dialog.showBackground}
       >
         <div className="flex flex-col space-y-4 py-2">
-          <DialogHeader className="text-center">
+          <DialogHeader className="text-left">
             <DialogTitle>{dialog.title}</DialogTitle>
           </DialogHeader>
-          <DialogDescription className="pt-4">
+          <DialogDescription className="pt-4 text-left">
             {typeof dialog.content === 'string' ? (
               <Label size="lg" weight="regular">
                 {dialog.content}

--- a/packages/ui/src/components/input/number-input.tsx
+++ b/packages/ui/src/components/input/number-input.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useEffect } from 'react';
 import { cn } from '../../lib/utils';
 
 interface NumberInputProps {
@@ -19,6 +19,17 @@ export const NumberInput: React.FC<NumberInputProps> = ({
   className,
 }) => {
   const inputsRef = useRef<Array<HTMLInputElement | null>>([]);
+
+  // autoFocus가 false일 때 포커스 방지
+  useEffect(() => {
+    if (!autoFocus) {
+      // 다이얼로그가 열릴 때 첫 번째 input에 포커스가 가는 것을 방지
+      const firstInput = inputsRef.current[0];
+      if (firstInput && document.activeElement === firstInput) {
+        firstInput.blur();
+      }
+    }
+  }, [autoFocus]);
 
   const handleChange = (idx: number, event: React.ChangeEvent<HTMLInputElement>): void => {
     const val = event.target.value.replace(/[^0-9]/g, '');
@@ -66,7 +77,8 @@ export const NumberInput: React.FC<NumberInputProps> = ({
           onChange={(event) => handleChange(idx, event)}
           onKeyDown={(event) => handleKeyDown(idx, event)}
           disabled={disabled}
-          autoFocus={idx === 0 && autoFocus}
+          {...(autoFocus && idx === 0 ? { autoFocus: true } : {})}
+          tabIndex={autoFocus ? undefined : -1}
           className={cn(
             'h-14 w-12',
             'rounded-lg border border-gray-200 bg-white',

--- a/packages/ui/src/components/study/create-attendance-code-dialog.tsx
+++ b/packages/ui/src/components/study/create-attendance-code-dialog.tsx
@@ -52,6 +52,7 @@ export function CreateAttendanceCodeDialog({
             length={6}
             value={inputValue}
             onChange={(value: string) => setInputValue(value)}
+            autoFocus={false}
           />
         </div>
         <DialogFooter className="mt-6 flex flex-row">

--- a/packages/ui/src/components/study/lecture-list-item.tsx
+++ b/packages/ui/src/components/study/lecture-list-item.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useState } from 'react';
 import { cn } from '../../lib/utils';
 import { Button } from '../button';
 import { IconButton } from '../icon-button';
@@ -133,18 +132,10 @@ function MobileLectureListItem({
   onEditClick,
   onDeleteClick,
 }: LectureCardProps): React.ReactElement {
-  const [isAttendanceCreated, setIsAttendanceCreated] = useState(
-    lecture?.isAttendanceCodeExist || false
-  );
-  const [isAssignmentCreated, setIsAssignmentCreated] = useState(
-    lecture?.isAssignmentExist || false
-  );
-  const [attendanceCompleted, setAttendanceCompleted] = useState(
-    lecture?.isAttendanceCompleted || false
-  );
-  const [assignmentCompleted, setAssignmentCompleted] = useState(
-    lecture?.isAssignmentCompleted || false
-  );
+  const isAttendanceCreated = lecture?.isAttendanceCodeExist || false;
+  const isAssignmentCreated = lecture?.isAssignmentExist || false;
+  const attendanceCompleted = lecture?.isAttendanceCompleted || false;
+  const assignmentCompleted = lecture?.isAssignmentCompleted || false;
 
   // 출석 관련 버튼만 상단에 배치 (Student일 때만)
   const attendanceButtons = [];
@@ -160,7 +151,7 @@ function MobileLectureListItem({
         <AttendanceCheckButton
           key="attendance-check"
           onClick={() => {
-            onAttendanceCheckClick?.(() => setAttendanceCompleted(true));
+            onAttendanceCheckClick?.(() => {});
           }}
           disabled={!isAttendanceCreated}
         />
@@ -175,7 +166,7 @@ function MobileLectureListItem({
         <DoAssignmentButton
           key="assignment-do"
           onClick={() => {
-            onDoAssignmentClick?.(() => setAssignmentCompleted(true));
+            onDoAssignmentClick?.(() => {});
           }}
           disabled={!isAssignmentCreated}
         />
@@ -199,7 +190,7 @@ function MobileLectureListItem({
           className="mx-1 my-1 rounded-sm px-3 py-2 text-left transition-all duration-200 hover:bg-gray-100"
           onClick={(e) => {
             e.stopPropagation();
-            onCreateAttendanceClick?.(() => setIsAttendanceCreated(true));
+            onCreateAttendanceClick?.(() => {});
           }}
         >
           <Label className="cursor-pointer">출석 생성</Label>
@@ -228,7 +219,7 @@ function MobileLectureListItem({
           className="mx-1 my-1 rounded-sm px-3 py-2 text-left transition-all duration-200 hover:bg-gray-100"
           onClick={(e) => {
             e.stopPropagation();
-            onCreateAssignmentClick?.(() => setIsAssignmentCreated(true));
+            onCreateAssignmentClick?.(() => {});
           }}
         >
           <Label className="cursor-pointer">과제 등록</Label>
@@ -304,10 +295,11 @@ function MobileLectureListItem({
         <Label
           size="lg"
           className={cn(
-            'cursor-pointer hover:opacity-70',
-            isStudent && 'underline decoration-gray-900 decoration-1 underline-offset-2'
+            (isStudent || isAdmin) && 'cursor-pointer hover:opacity-70',
+            (isStudent || isAdmin) &&
+              'underline decoration-gray-900 decoration-1 underline-offset-2'
           )}
-          onClick={onTitleClick}
+          onClick={isStudent || isAdmin ? onTitleClick : undefined}
         >
           {lecture?.title || '강의 제목 없음'}
         </Label>
@@ -318,18 +310,10 @@ function MobileLectureListItem({
 }
 
 function DesktopLectureCardListItem(props: LectureCardProps): React.ReactElement {
-  const [isAttendanceCreated, setIsAttendanceCreated] = useState(
-    props.lecture?.isAttendanceCodeExist || false
-  );
-  const [isAssignmentCreated, setIsAssignmentCreated] = useState(
-    props.lecture?.isAssignmentExist || false
-  );
-  const [attendanceCompleted, setAttendanceCompleted] = useState(
-    props.lecture?.isAttendanceCompleted
-  );
-  const [assignmentCompleted, setAssignmentCompleted] = useState(
-    props.lecture?.isAssignmentCompleted
-  );
+  const isAttendanceCreated = props.lecture?.isAttendanceCodeExist || false;
+  const isAssignmentCreated = props.lecture?.isAssignmentExist || false;
+  const attendanceCompleted = props.lecture?.isAttendanceCompleted;
+  const assignmentCompleted = props.lecture?.isAssignmentCompleted;
 
   const {
     lecture,
@@ -357,7 +341,7 @@ function DesktopLectureCardListItem(props: LectureCardProps): React.ReactElement
         <AttendanceCheckButton
           key="attendance-check"
           onClick={() => {
-            onAttendanceCheckClick?.(() => setAttendanceCompleted(true));
+            onAttendanceCheckClick?.(() => {});
           }}
           disabled={!isAttendanceCreated}
         />
@@ -372,7 +356,7 @@ function DesktopLectureCardListItem(props: LectureCardProps): React.ReactElement
         <DoAssignmentButton
           key="assignment-do"
           onClick={() => {
-            onDoAssignmentClick?.(() => setAssignmentCompleted(true));
+            onDoAssignmentClick?.(() => {});
           }}
           disabled={!isAssignmentCreated}
         />
@@ -395,7 +379,7 @@ function DesktopLectureCardListItem(props: LectureCardProps): React.ReactElement
           className="mx-1 my-1 rounded-sm px-3 py-2 text-left transition-all duration-200 hover:bg-gray-100"
           onClick={(e) => {
             e.stopPropagation();
-            onCreateAttendanceClick?.(() => setIsAttendanceCreated(true));
+            onCreateAttendanceClick?.(() => {});
           }}
         >
           <Label className="cursor-pointer">출석 생성</Label>
@@ -424,7 +408,7 @@ function DesktopLectureCardListItem(props: LectureCardProps): React.ReactElement
           className="mx-1 my-1 rounded-sm px-3 py-2 text-left transition-all duration-200 hover:bg-gray-100"
           onClick={(e) => {
             e.stopPropagation();
-            onCreateAssignmentClick?.(() => setIsAssignmentCreated(true));
+            onCreateAssignmentClick?.(() => {});
           }}
         >
           <Label className="cursor-pointer">과제 등록</Label>
@@ -489,10 +473,10 @@ function DesktopLectureCardListItem(props: LectureCardProps): React.ReactElement
         <Label
           size="lg"
           className={cn(
-            props.isStudent &&
+            (props.isStudent || props.isAdmin) &&
               'cursor-pointer underline decoration-gray-900 decoration-1 underline-offset-2 hover:opacity-70'
           )}
-          onClick={props.onTitleClick}
+          onClick={props.isStudent || props.isAdmin ? props.onTitleClick : undefined}
         >
           {lecture?.title || '강의 제목 없음'}
         </Label>
@@ -511,7 +495,7 @@ function DesktopLectureCardListItem(props: LectureCardProps): React.ReactElement
               {!isAttendanceCreated ? (
                 <CreateCodeButton
                   onClick={() => {
-                    onCreateAttendanceClick?.(() => setIsAttendanceCreated(true));
+                    onCreateAttendanceClick?.(() => {});
                   }}
                 />
               ) : (
@@ -522,7 +506,7 @@ function DesktopLectureCardListItem(props: LectureCardProps): React.ReactElement
               {!isAssignmentCreated ? (
                 <CreateAssignmentButton
                   onClick={() => {
-                    onCreateAssignmentClick?.(() => setIsAssignmentCreated(true));
+                    onCreateAssignmentClick?.(() => {});
                   }}
                 />
               ) : (

--- a/packages/ui/src/components/study/mobile-study-button.tsx
+++ b/packages/ui/src/components/study/mobile-study-button.tsx
@@ -53,7 +53,7 @@ export function MobileStudyButton({
   };
 
   return (
-    <div className="mt-4 w-full md:hidden">
+    <div className="fixed bottom-0 left-0 right-0 z-50 p-4 md:hidden">
       {hasRecruitmentDates &&
         !isAdmin &&
         !studyData?.isStudent &&

--- a/packages/ui/src/hooks/use-announcement-form.ts
+++ b/packages/ui/src/hooks/use-announcement-form.ts
@@ -180,6 +180,14 @@ export function useAnnouncementForm({
       }
     }
 
+    // 회차별 공지가 선택된 경우 회차 입력 검증
+    if (formData.announcementType === 'STUDY' && formData.studyAnnounceType === '회차별 공지') {
+      if (!formData.lectureRound) {
+        DialogUtil.showError('회차별 공지를 선택한 경우 회차를 입력해주세요.');
+        return;
+      }
+    }
+
     // 최종 데이터 정리
     const requestData: CreateAnnouncementForm = {
       title: formData.title.trim(),


### PR DESCRIPTION
## 🔀 PR 개요
공지사항 및 스터디 기능 전반에 걸친 여러 UI/UX 개선사항과 더 나은 유지보수성을 위한 코드베이스 간소화를 도입
다이얼로그 동작 개선, 폼 유효성 검사 강화, 성공적인 뮤테이션 후 네비게이션 업데이트, 강의 목록 아이템 상태 관리 리팩토링이 주요 변경사항

<br/>

## 📌 주요 변경 사항
- 공지사항 생성/수정 성공 후 이전 페이지로 자동 네비게이션 추가
- "회차별 공지" 선택 시 강의 회차 필수 입력 유효성 검사 강화
- 스터디 상세 페이지 신청 버튼을 확인 다이얼로그로 변경하여 일관성 향상
- 모바일 스터디 버튼을 화면 하단 고정으로 접근성 개선
- 강의 목록 아이템에서 불필요한 로컬 상태 제거 및 권한 기반 클릭 제한
- NumberInput 컴포넌트의 자동 포커스 및 접근성 개선

<br/>

## 📝 작업 상세 내용
**공지사항 및 스터디 기능 개선**
- `useUpdateInstructorAnnouncement` 및 `useCreateStudyAnnouncement` 훅에서 `router.back()` 사용하여 공지사항 생성 또는 업데이트 성공 후 이전 페이지로 돌아가는 네비게이션 로직 추가
- "회차별 공지" 선택 시 강의 회차가 누락된 경우 오류 다이얼로그를 표시하도록 공지사항 폼의 유효성 검사 개선
- 더 일관된 사용자 경험을 위해 스터디 상세 페이지의 신청 버튼 다이얼로그를 커스텀 다이얼로그에서 확인 다이얼로그로 변경

**UI/UX 개선**
- 더 나은 접근성을 위해 모바일 스터디 버튼을 화면 하단에 고정하도록 업데이트
- 다양한 기기에서 더 나은 레이아웃을 위해 모바일 스터디 상세 페이지의 패딩 조정
- 가독성 향상을 위해 확인 다이얼로그의 다이얼로그 헤더 및 설명 정렬을 왼쪽 정렬로 수정

**강의 목록 아이템 리팩토링**
- 출석 및 과제 상태에 대한 불필요한 로컬 상태를 제거하고 대신 props에 직접 의존하도록 모바일 및 데스크톱 강의 목록 아이템 리팩토링
- 클릭 가능한 강의 제목을 학생 및 관리자에게만 제한

**입력 컴포넌트 개선**
- `autoFocus`가 false일 때 자동 포커스를 방지하고 접근성을 위한 탭 인덱스 처리를 업데이트하도록 `NumberInput` 컴포넌트 개선
- 출석 코드 다이얼로그가 입력에 자동 포커스되지 않도록 보장

<br/>

## 🔗 관련 이슈/PR
- #111 

<br/>

## 💬 기타 참고사항
없음.