### PR TITLE
Feat: 스터디 주의사항 처리 및 팝업 동기화 개선

### DIFF
--- a/apps/intra/src/app/page.tsx
+++ b/apps/intra/src/app/page.tsx
@@ -5,7 +5,7 @@ import { cookies } from 'next/headers';
 
 export default async function Home(): Promise<React.ReactElement> {
   const cookieStore = cookies();
-  const authCookie = cookieStore.get('access');
+  const authCookie = cookieStore.get(process.env.ACCESS_TOKEN_KEY || '');
   const isAuthenticated = Boolean(authCookie?.value);
 
   return (

--- a/apps/intra/src/features/study/hooks/page/use-study-detail-page-state.ts
+++ b/apps/intra/src/features/study/hooks/page/use-study-detail-page-state.ts
@@ -3,7 +3,6 @@ import { DialogUtil } from '@hiarc-platform/ui';
 import { useRouter, useParams } from 'next/navigation';
 import { useState, useEffect } from 'react';
 import { useStudy } from '../study-common/query/use-study';
-import React from 'react';
 
 export function useStudyDetailPageState() {
   const router = useRouter();
@@ -22,12 +21,11 @@ export function useStudyDetailPageState() {
   };
 
   const handleApplyClick = (): void => {
-    DialogUtil.showConfirm(
-      '기초/초급 스터디는 동일 시간에 진행되어 중복 신청이 불가합니다.',
-      () => applyToStudy(studyId),
-      undefined,
-      { title: '유의사항' }
-    );
+    const message = studyData?.precaution || `${studyData?.name}을 신청하시겠습니까?`;
+    const title = studyData?.precaution ? '유의사항' : '스터디 신청';
+
+    console.log(studyData?.precaution);
+    DialogUtil.showConfirm(message, () => applyToStudy(studyId), undefined, { title });
   };
 
   const handleBackClick = (): void => {

--- a/apps/intra/src/shared/components/ui/header/authenticated-mobile-section.tsx
+++ b/apps/intra/src/shared/components/ui/header/authenticated-mobile-section.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button, DialogUtil, FadeIn } from '@hiarc-platform/ui';
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 import { IconButton } from '@hiarc-platform/ui';
 import useLogout from '@/features/auth/hooks/mutation/use-logout';
 import useRecruitNotificationRead from '@/features/auth/hooks/mutation/use-recruit-notification-read';
@@ -12,6 +12,7 @@ import { SignupPopup } from './signup-popup';
 
 export function AuthenticatedMobileSection(): React.ReactElement {
   const router = useRouter();
+  const pathname = usePathname();
   const logoutMutation = useLogout();
   const recruitNotificationReadMutation = useRecruitNotificationRead();
   const [myInfo, setMyInfo] = useState<MyInfo | null>(null);
@@ -45,8 +46,11 @@ export function AuthenticatedMobileSection(): React.ReactElement {
         const userData = await authApi.GET_ME();
         setMyInfo(userData);
 
-        // approvedNotification이 있으면 팝업 표시
-        if (userData?.approvedNotification) {
+        // 메인페이지가 아니거나 세션에서 팝업을 닫은 상태면 표시하지 않음
+        const isPopupDismissed = sessionStorage.getItem('signupPopupDismissed') === 'true';
+        const isMainPage = pathname === '/' || pathname === '';
+
+        if (userData?.approvedNotification && isMainPage && !isPopupDismissed) {
           setIsPopupOpen(true);
         }
       } catch (error) {
@@ -78,6 +82,19 @@ export function AuthenticatedMobileSection(): React.ReactElement {
       document.removeEventListener('mousedown', handleClickOutside);
     };
   }, [isPopupOpen]);
+
+  // 커스텀 이벤트로 데스크톱-모바일 간 동기화
+  useEffect(() => {
+    const handlePopupDismiss = () => {
+      setIsPopupOpen(false);
+    };
+
+    window.addEventListener('signupPopupDismissed', handlePopupDismiss);
+
+    return () => {
+      window.removeEventListener('signupPopupDismissed', handlePopupDismiss);
+    };
+  }, []);
 
   return (
     <div className="flex items-center gap-2">
@@ -120,6 +137,10 @@ export function AuthenticatedMobileSection(): React.ReactElement {
                   if (myInfo?.approvedNotification?.semesterId) {
                     recruitNotificationReadMutation.mutate(myInfo.approvedNotification.semesterId);
                   }
+                  // 세션스토리지에 팝업 닫힘 상태 저장
+                  sessionStorage.setItem('signupPopupDismissed', 'true');
+                  // 커스텀 이벤트 발생으로 다른 컴포넌트에 알림
+                  window.dispatchEvent(new CustomEvent('signupPopupDismissed'));
                   setIsPopupOpen(false);
                 }}
               />

--- a/apps/intra/src/shared/components/ui/header/authenticated-user-section.tsx
+++ b/apps/intra/src/shared/components/ui/header/authenticated-user-section.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button, DialogUtil, FadeIn } from '@hiarc-platform/ui';
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 import { IconButton } from '@hiarc-platform/ui';
 import { StudyAttendanceDialog } from '@/features/study/components/study-attendance-dialog';
 import { studyMemberApi } from '@/features/study/api';
@@ -15,6 +15,7 @@ import { useCurrentSemester } from '@/features/semester/hooks/use-current-semest
 
 export function AuthenticatedUserSection(): React.ReactElement {
   const router = useRouter();
+  const pathname = usePathname();
   const logoutMutation = useLogout();
   const recruitNotificationReadMutation = useRecruitNotificationRead();
   const { data: currentSemesterData } = useCurrentSemester();
@@ -75,8 +76,11 @@ export function AuthenticatedUserSection(): React.ReactElement {
         const userData = await authApi.GET_ME();
         setMyInfo(userData);
 
-        // approvedNotification이 있으면 팝업 표시
-        if (userData?.approvedNotification) {
+        // 메인페이지가 아니거나 세션에서 팝업을 닫은 상태면 표시하지 않음
+        const isPopupDismissed = sessionStorage.getItem('signupPopupDismissed') === 'true';
+        const isMainPage = pathname === '/' || pathname === '';
+
+        if (userData?.approvedNotification && isMainPage && !isPopupDismissed) {
           setIsPopupOpen(true);
         }
       } catch (error) {
@@ -108,6 +112,19 @@ export function AuthenticatedUserSection(): React.ReactElement {
       document.removeEventListener('mousedown', handleClickOutside);
     };
   }, [isPopupOpen]);
+
+  // 커스텀 이벤트로 데스크톱-모바일 간 동기화
+  useEffect(() => {
+    const handlePopupDismiss = () => {
+      setIsPopupOpen(false);
+    };
+
+    window.addEventListener('signupPopupDismissed', handlePopupDismiss);
+    
+    return () => {
+      window.removeEventListener('signupPopupDismissed', handlePopupDismiss);
+    };
+  }, []);
 
   const handleAttendanceCheck = async (): Promise<void> => {
     try {
@@ -154,6 +171,10 @@ export function AuthenticatedUserSection(): React.ReactElement {
                   if (myInfo?.approvedNotification?.semesterId) {
                     recruitNotificationReadMutation.mutate(myInfo.approvedNotification.semesterId);
                   }
+                  // 세션스토리지에 팝업 닫힘 상태 저장
+                  sessionStorage.setItem('signupPopupDismissed', 'true');
+                  // 커스텀 이벤트 발생으로 다른 컴포넌트에 알림
+                  window.dispatchEvent(new CustomEvent('signupPopupDismissed'));
                   setIsPopupOpen(false);
                 }}
               />

--- a/packages/shared/src/types/study/study.ts
+++ b/packages/shared/src/types/study/study.ts
@@ -61,6 +61,7 @@ export const Study = {
       instructorBojHandle: (data.instructorBojHandle as string) || null,
       isInstructor: (data.isInstructor as boolean) || null,
       isStudent: (data.isStudent as boolean) || null,
+      precaution: (data.precaution as string) || null,
     };
 
     // Add computed properties

--- a/packages/ui/src/components/study/study-info-section/study-info.tsx
+++ b/packages/ui/src/components/study/study-info-section/study-info.tsx
@@ -24,13 +24,7 @@ export function StudyInfo({ studyData }: { studyData?: Study | null }): React.Re
       <CategoryText category={'스터디장'} content={studyData?.instructorNameHandle || '-'} />
       <CategoryText
         category={'진행방식'}
-        content={
-          studyData?.isOnline === true
-            ? '온라인'
-            : studyData?.isOnline === false
-              ? '오프라인'
-              : '온라인'
-        }
+        content={studyData?.isOnline == true ? '온라인' : '오프라인'}
       />
       <CategoryText category={'언어'} content={studyData?.lang || '-'} />
     </div>


### PR DESCRIPTION
## 🔀 PR 개요
데스크톱과 모바일 간 팝업 해제 동기화, 팝업 표시 로직 개선, 스터디 신청 메시징 향상

<br/>

## 📌 주요 변경 사항
- 메인 페이지에서만 회원가입 알림 팝업이 표시되도록 표시 로직 개선
- 데스크톱과 모바일 간 팝업 해제 상태 동기화를 위한 커스텀 이벤트 처리 구현
- 스터디별 주의사항을 활용한 스터디 신청 확인 다이얼로그 메시징 개선
- 접근 토큰 쿠키 검색에 환경 변수 사용으로 구성 가능성 향상
- 사용하지 않는 임포트 제거 및 로직 간소화

<br/>

## 📝 작업 상세 내용
**회원가입 팝업 동기화 및 표시 로직**
- `AuthenticatedMobileSection` 및 `AuthenticatedUserSection` 컴포넌트 모두에서 메인 페이지(`'/'` 또는 `''`)에서만 그리고 세션에서 해제되지 않은 경우에만 회원가입 알림 팝업을 표시하는 로직 추가
- 기기 간 일관된 UI 상태를 보장하기 위해 데스크톱과 모바일 뷰 간 팝업 해제를 동기화하는 커스텀 이벤트 처리(`signupPopupDismissed`) 구현
- 팝업 해제 시 해제 상태를 `sessionStorage`에 저장하고 다른 컴포넌트에 알리기 위한 커스텀 이벤트 발송

**스터디 신청 개선**
- 사용자에게 더 컨텍스트별 메시징을 제공하기 위해 스터디 데이터에서 `precaution` 필드가 있는 경우 이를 사용하도록 스터디 신청 확인 다이얼로그 업데이트
- 위 기능을 지원하기 위해 `Study` 타입에 `precaution` 속성 추가

**경미한 코드 정리**
- 사용하지 않는 임포트 제거 및 스터디 정보 표시와 온라인/오프라인 상태에 대한 로직 간소화

**인증 로직 업데이트**
- 구성 가능성 향상을 위해 접근 토큰 쿠키 검색 시 키에 환경 변수를 사용하도록 변경

<br/>

## 🔗 관련 이슈/PR
- #122 

<br/>

## 💬 기타 참고사항
이번 업데이트를 통해 사용자 인터페이스의 일관성이 크게 향상되었으며, 특히 모바일과 데스크톱 간 상태 동기화로 더 나은 사용자 경험을 제공할 수 있게 되었습니다. 또한 스터디별 맞춤 메시징으로 사용자에게 더 유용한 정보를 제공할 수 있게 되었습니다.