### PR TITLE
Fix: 마이페이지 및 학회원 페이지 모바일 반응형 강화

### DIFF
--- a/apps/intra/src/app/my/page.tsx
+++ b/apps/intra/src/app/my/page.tsx
@@ -1,22 +1,8 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
-import { useRouter } from 'next/navigation';
-import { PageLayout, DialogUtil } from '@hiarc-platform/ui';
+import { PageLayout } from '@hiarc-platform/ui';
 import { DesktopMyPage, MobileMyPage } from '@/features/member/pages/my-page';
 
 export default function MyPage(): React.ReactElement {
-  const router = useRouter();
-  const dialogShown = useRef(false);
-
-  useEffect(() => {
-    if (!dialogShown.current) {
-      dialogShown.current = true;
-      DialogUtil.showError('현재 기능 준비중입니다', () => {
-        router.push('/');
-      });
-    }
-  }, [router]);
-
-  return <PageLayout desktopChildren={<div />} mobileChildren={<div />} />;
+  return <PageLayout desktopChildren={<DesktopMyPage />} mobileChildren={<MobileMyPage />} />;
 }

--- a/apps/intra/src/features/award/components/award-section/index.tsx
+++ b/apps/intra/src/features/award/components/award-section/index.tsx
@@ -26,7 +26,10 @@ export function AwardSection({
   return (
     <div className={cn('flex w-full flex-col', className)}>
       <div className="flex items-center justify-between">
-        <Title size="sm" weight="bold">
+        <Title size="sm" weight="bold" className="hidden md:block">
+          참여한 대회
+        </Title>
+        <Title size="xs" weight="bold" className="md:hidden">
           참여한 대회
         </Title>
         {isMe && (

--- a/apps/intra/src/features/member/components/hiting-section/desktop-hiting-section.tsx
+++ b/apps/intra/src/features/member/components/hiting-section/desktop-hiting-section.tsx
@@ -1,0 +1,70 @@
+import { Label, Title } from '@hiarc-platform/ui';
+import { SectionContainer } from '../section-container';
+import { HitingListItem } from './hiting-list-item';
+import { HitingStatistics } from './hiting-statistics';
+import { RatingRecord } from '@/features/member/types/model/rating-record';
+
+interface DesktopHitingSectionProps {
+  season: number;
+  total: number;
+  today: number;
+  ratingRecords?: RatingRecord[];
+  className?: string;
+  isMe?: boolean;
+}
+
+export function DesktopHitingSection({
+  season,
+  total,
+  today,
+  ratingRecords,
+  className,
+  isMe = true,
+}: DesktopHitingSectionProps): React.ReactElement {
+  return (
+    <div className={`flex w-full flex-col gap-4 ${className}`}>
+      {/* Title */}
+      <Title size="sm" weight="bold">
+        하이팅
+      </Title>
+
+      {/* All statistics */}
+      <div className="flex w-full gap-4">
+        <HitingStatistics label="시즌" value={season} />
+        <HitingStatistics label="누적" value={total} />
+        <HitingStatistics label="오늘" value={today} increased={today > 0} />
+      </div>
+
+      <SectionContainer>
+        {ratingRecords && ratingRecords.length > 0 ? (
+          <div className="flex w-full flex-col gap-4">
+            {ratingRecords.map((record, index) => (
+              <HitingListItem
+                key={index}
+                name={record.description ?? ''}
+                rank={record.ranking ?? 0}
+                div={'DIV_1'}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="flex justify-center">
+            <Label size="lg" weight="regular" className="text-gray-700">
+              {isMe ? '하이팅에 참여하시고, 10위 안에 도전해보세요!' : '하이팅 참여 기록이 없어요.'}
+            </Label>
+            {isMe && (
+              <Label
+                size="lg"
+                weight="regular"
+                className="ml-2 cursor-pointer text-gray-700 underline"
+                onClick={() => window.open('https://rating.hiarc-official.com', '_blank')}
+              >
+                하이팅 바로가기
+              </Label>
+            )}
+          </div>
+        )}
+      </SectionContainer>
+    </div>
+  );
+}

--- a/apps/intra/src/features/member/components/hiting-section/index.tsx
+++ b/apps/intra/src/features/member/components/hiting-section/index.tsx
@@ -1,8 +1,6 @@
-import { Label, Title } from '@hiarc-platform/ui';
-import { SectionContainer } from '../section-container';
-import { HitingListItem } from './hiting-list-item';
-import { HitingStatistics } from './hiting-statistics';
 import { RatingRecord } from '@/features/member/types/model/rating-record';
+import { DesktopHitingSection } from './desktop-hiting-section';
+import { MobileHitingSection } from './mobile-hiting-section';
 
 interface HitingSectionProps {
   season: number;
@@ -22,45 +20,30 @@ export function HitingSection({
   isMe = true,
 }: HitingSectionProps): React.ReactElement {
   return (
-    <div className={`flex w-full flex-col gap-4 ${className}`}>
-      <Title size="sm" weight="bold">
-        하이팅
-      </Title>
-      <div className="flex w-full gap-4">
-        <HitingStatistics label="시즌" value={season} />
-        <HitingStatistics label="누적" value={total} />
-        <HitingStatistics label="오늘" value={today} increased={today > 0} />
+    <>
+      {/* Desktop version */}
+      <div className="hidden md:block">
+        <DesktopHitingSection
+          season={season}
+          total={total}
+          today={today}
+          ratingRecords={ratingRecords}
+          className={className}
+          isMe={isMe}
+        />
       </div>
-      <SectionContainer>
-        {ratingRecords && ratingRecords.length > 0 ? (
-          <div className="flex w-full flex-col gap-4">
-            {ratingRecords.map((record, index) => (
-              <HitingListItem
-                key={index}
-                name={record.description ?? ''}
-                rank={record.ranking ?? 0}
-                div={'DIV_1'}
-              />
-            ))}
-          </div>
-        ) : (
-          <div className="flex justify-center">
-            <Label size="lg" weight="regular" className="text-gray-700">
-              {isMe ? '하이팅에 참여하시고, 10위 안에 도전해보세요!' : '하이팅 참여 기록이 없어요.'}
-            </Label>
-            {isMe && (
-              <Label
-                size="lg"
-                weight="regular"
-                className="ml-2 cursor-pointer text-gray-700 underline"
-                onClick={() => window.open('https://rating.hiarc-official.com', '_blank')}
-              >
-                하이팅 바로가기
-              </Label>
-            )}
-          </div>
-        )}
-      </SectionContainer>
-    </div>
+
+      {/* Mobile version */}
+      <div className="block md:hidden">
+        <MobileHitingSection
+          season={season}
+          total={total}
+          today={today}
+          ratingRecords={ratingRecords}
+          className={className}
+          isMe={isMe}
+        />
+      </div>
+    </>
   );
 }

--- a/apps/intra/src/features/member/components/hiting-section/mobile-hiting-section.tsx
+++ b/apps/intra/src/features/member/components/hiting-section/mobile-hiting-section.tsx
@@ -1,0 +1,83 @@
+import { Label, Title } from '@hiarc-platform/ui';
+import { SectionContainer } from '../section-container';
+import { HitingListItem } from './hiting-list-item';
+import { HitingStatistics } from './hiting-statistics';
+import { RatingRecord } from '@/features/member/types/model/rating-record';
+import Image from 'next/image';
+
+interface MobileHitingSectionProps {
+  season: number;
+  total: number;
+  today: number;
+  ratingRecords?: RatingRecord[];
+  className?: string;
+  isMe?: boolean;
+}
+
+export function MobileHitingSection({
+  season,
+  total,
+  today,
+  ratingRecords,
+  className,
+  isMe = true,
+}: MobileHitingSectionProps): React.ReactElement {
+  return (
+    <div className={`flex w-full flex-col gap-4 ${className}`}>
+      {/* Title with today stats */}
+      <div className="flex items-center justify-between">
+        <Title size="xs" weight="bold">
+          하이팅
+        </Title>
+        <div className="flex items-center gap-2">
+          <Label size="md" weight="regular" className="text-gray-600">
+            오늘
+          </Label>
+          <Title size="xs" weight="bold">
+            {today}
+          </Title>
+          {today > 0 && (
+            <Image src="/shared-assets/ArrowUp.svg" alt="ArrowUp" width={16} height={16} />
+          )}
+        </div>
+      </div>
+
+      {/* Season and total only */}
+      <div className="flex w-full gap-4">
+        <HitingStatistics label="시즌" value={season} />
+        <HitingStatistics label="누적" value={total} />
+      </div>
+
+      <SectionContainer>
+        {ratingRecords && ratingRecords.length > 0 ? (
+          <div className="flex w-full flex-col gap-4">
+            {ratingRecords.map((record, index) => (
+              <HitingListItem
+                key={index}
+                name={record.description ?? ''}
+                rank={record.ranking ?? 0}
+                div={'DIV_1'}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="flex flex-col  justify-center">
+            <Label size="lg" weight="regular" className="text-center text-gray-700">
+              {isMe ? '하이팅에 참여하시고, 10위 안에 도전해보세요!' : '하이팅 참여 기록이 없어요.'}
+            </Label>
+            {isMe && (
+              <Label
+                size="lg"
+                weight="regular"
+                className="cursor-pointer text-center text-gray-700 underline"
+                onClick={() => window.open('https://rating.hiarc-official.com', '_blank')}
+              >
+                하이팅 바로가기
+              </Label>
+            )}
+          </div>
+        )}
+      </SectionContainer>
+    </div>
+  );
+}

--- a/apps/intra/src/features/member/components/streak-section/contribution-grid.tsx
+++ b/apps/intra/src/features/member/components/streak-section/contribution-grid.tsx
@@ -21,30 +21,16 @@ const monthLabels = [
   'Dec',
 ];
 
-interface ContributionData {
-  date: string;
-  count: number;
+interface StreakData {
+  date?: string | null;
+  value?: boolean | null;
 }
 
 interface Props {
-  data: ContributionData[];
+  data: StreakData[];
 }
 
-const getColor = (count: number): string => {
-  if (count === 0) {
-    return 'bg-gray-100';
-  }
-  if (count < 3) {
-    return 'bg-green-200';
-  }
-  if (count < 5) {
-    return 'bg-green-300';
-  }
-  if (count < 10) {
-    return 'bg-green-400';
-  }
-  return 'bg-green-500';
-};
+const getColor = (hasStreak: boolean): string => (hasStreak ? 'bg-primary-100/50' : 'bg-gray-100');
 
 export function ContributionGrid({ data }: Props): React.ReactElement {
   const currentYear = new Date().getFullYear();
@@ -55,9 +41,11 @@ export function ContributionGrid({ data }: Props): React.ReactElement {
   const startDayOfWeek = getDay(yearStart);
   const totalWeeks = Math.ceil((totalDaysInYear + startDayOfWeek) / 7);
 
-  const dateMap = new Map<string, number>();
-  data.forEach(({ date, count }) => {
-    dateMap.set(date, count);
+  const dateMap = new Map<string, boolean>();
+  data.forEach(({ date, value }) => {
+    if (date) {
+      dateMap.set(date, value || false);
+    }
   });
 
   const gridWidth = totalWeeks * boxSize + (totalWeeks - 1) * boxGap;
@@ -116,13 +104,13 @@ export function ContributionGrid({ data }: Props): React.ReactElement {
 
               const currentDate = addDays(yearStart, dayOffset);
               const dateString = format(currentDate, 'yyyy-MM-dd');
-              const count = dateMap.get(dateString) || 0;
+              const hasStreak = dateMap.get(dateString) || false;
 
               return (
                 <div
                   key={dateString}
-                  title={`${dateString}: ${count} contributions`}
-                  className={cn('h-2 w-2', getColor(count))}
+                  title={`${dateString}: ${hasStreak ? 'streak' : 'no streak'}`}
+                  className={cn('h-2 w-2', getColor(hasStreak))}
                 />
               );
             })}

--- a/apps/intra/src/features/member/components/streak-section/contribution-grid.tsx
+++ b/apps/intra/src/features/member/components/streak-section/contribution-grid.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { cn } from '@hiarc-platform/ui';
-import { addDays, differenceInDays, endOfYear, format, getDay, startOfYear } from 'date-fns';
+import { addDays, differenceInDays, format, getDay } from 'date-fns';
+import { useEffect, useRef } from 'react';
 
 const daysInWeek = 7;
 const boxSize = 8;
@@ -33,9 +34,10 @@ interface Props {
 const getColor = (hasStreak: boolean): string => (hasStreak ? 'bg-primary-100/50' : 'bg-gray-100');
 
 export function ContributionGrid({ data }: Props): React.ReactElement {
-  const currentYear = new Date().getFullYear();
-  const yearStart = startOfYear(new Date(currentYear, 0, 1));
-  const yearEnd = endOfYear(new Date(currentYear, 11, 31));
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const today = new Date();
+  const yearStart = addDays(today, -365); // 365일 전
+  const yearEnd = today; // 오늘
 
   const totalDaysInYear = differenceInDays(yearEnd, yearStart) + 1;
   const startDayOfWeek = getDay(yearStart);
@@ -54,16 +56,27 @@ export function ContributionGrid({ data }: Props): React.ReactElement {
     const positions: Array<{ month: string; left: number }> = [];
     const monthStarts: number[] = [];
 
-    for (let month = 0; month < 12; month++) {
-      const monthStart = new Date(currentYear, month, 1);
-      const daysSinceYearStart = differenceInDays(monthStart, yearStart);
+    // 시작 월부터 현재 월까지 순회
+    const currentDate = new Date(yearStart);
+    currentDate.setDate(1); // 각 월의 1일로 설정
+
+    while (currentDate <= yearEnd) {
+      const daysSinceYearStart = differenceInDays(currentDate, yearStart);
       const weekPosition = Math.floor((daysSinceYearStart + startDayOfWeek) / 7);
       const left = weekPosition * (boxSize + boxGap);
 
-      if (monthStarts.length === 0 || weekPosition > monthStarts[monthStarts.length - 1]) {
-        positions.push({ month: monthLabels[month], left });
+      // 중복되지 않고 그리드 범위 내에 있는 경우만 추가
+      if (
+        daysSinceYearStart >= 0 &&
+        weekPosition < totalWeeks &&
+        (monthStarts.length === 0 || weekPosition > monthStarts[monthStarts.length - 1])
+      ) {
+        positions.push({ month: monthLabels[currentDate.getMonth()], left });
         monthStarts.push(weekPosition);
       }
+
+      // 다음 월로 이동
+      currentDate.setMonth(currentDate.getMonth() + 1);
     }
 
     return positions;
@@ -71,51 +84,64 @@ export function ContributionGrid({ data }: Props): React.ReactElement {
 
   const monthPositions = getMonthPositions();
 
+  // 컴포넌트 마운트 시 오른쪽 끝으로 스크롤
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollLeft = scrollRef.current.scrollWidth;
+    }
+  }, [data]);
+
   return (
     <div className="relative">
-      <div className="relative mb-2 h-4" style={{ width: `${gridWidth}px` }}>
-        {monthPositions.map(({ month, left }) => (
-          <span
-            key={month}
-            className="absolute text-xs text-gray-600"
-            style={{ left: `${left}px` }}
-          >
-            {month}
-          </span>
-        ))}
-      </div>
-
-      <div
-        className="inline-flex"
-        style={{
-          width: `${gridWidth}px`,
-          gap: `${boxGap}px`,
-          minWidth: `${gridWidth}px`,
-        }}
-      >
-        {Array.from({ length: totalWeeks }).map((_, weekIndex) => (
-          <div key={weekIndex} className="flex flex-col" style={{ gap: `${boxGap}px` }}>
-            {Array.from({ length: daysInWeek }).map((_, dayIndex) => {
-              const dayOffset = weekIndex * daysInWeek + dayIndex - startDayOfWeek;
-
-              if (dayOffset < 0 || dayOffset >= totalDaysInYear) {
-                return <div key={`empty-${weekIndex}-${dayIndex}`} className="h-2 w-2" />;
-              }
-
-              const currentDate = addDays(yearStart, dayOffset);
-              const dateString = format(currentDate, 'yyyy-MM-dd');
-              const hasStreak = dateMap.get(dateString) || false;
-
-              return (
-                <div
-                  key={dateString}
-                  title={`${dateString}: ${hasStreak ? 'streak' : 'no streak'}`}
-                  className={cn('h-2 w-2', getColor(hasStreak))}
-                />
-              );
-            })}
+      <div ref={scrollRef} className="overflow-x-auto" style={{ width: '100%' }}>
+        <div className="flex flex-col" style={{ minWidth: `${gridWidth}px` }}>
+          {/* 월 헤더 */}
+          <div className="relative mb-2 h-4" style={{ width: `${gridWidth}px` }}>
+            {monthPositions.map(({ month, left }) => (
+              <span
+                key={month}
+                className="absolute text-xs text-gray-600"
+                style={{ left: `${left}px` }}
+              >
+                {month}
+              </span>
+            ))}
           </div>
-        ))}
+
+          {/* 그리드 */}
+          <div
+            className="inline-flex"
+            style={{
+              width: `${gridWidth}px`,
+              gap: `${boxGap}px`,
+              minWidth: `${gridWidth}px`,
+            }}
+          >
+            {Array.from({ length: totalWeeks }).map((_, weekIndex) => (
+              <div key={weekIndex} className="flex flex-col" style={{ gap: `${boxGap}px` }}>
+                {Array.from({ length: daysInWeek }).map((_, dayIndex) => {
+                  const dayOffset = weekIndex * daysInWeek + dayIndex - startDayOfWeek;
+
+                  if (dayOffset < 0 || dayOffset >= totalDaysInYear) {
+                    return <div key={`empty-${weekIndex}-${dayIndex}`} className="h-2 w-2" />;
+                  }
+
+                  const currentDate = addDays(yearStart, dayOffset);
+                  const dateString = format(currentDate, 'yyyy-MM-dd');
+                  const hasStreak = dateMap.get(dateString) || false;
+
+                  return (
+                    <div
+                      key={dateString}
+                      title={`${dateString}: ${hasStreak ? 'streak' : 'no streak'}`}
+                      className={cn('h-2 w-2', getColor(hasStreak))}
+                    />
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/apps/intra/src/features/member/components/streak-section/index.tsx
+++ b/apps/intra/src/features/member/components/streak-section/index.tsx
@@ -1,16 +1,22 @@
 import { cn, Divider, Label, Title } from '@hiarc-platform/ui';
 import { SectionContainer } from '../section-container';
 import { ContributionGrid } from './contribution-grid';
+import { StreakData } from '../../types/model/streak-data';
+import { DateUtil } from '@hiarc-platform/shared';
 
 interface StreakSectionProps {
   totalDays?: number;
   currentSeasonDays?: number;
+  streakStartAt?: string;
+  streakData?: StreakData[];
   className?: string;
 }
 
 export function StreakSection({
   totalDays,
   currentSeasonDays,
+  streakStartAt,
+  streakData,
   className,
 }: StreakSectionProps): React.ReactElement {
   return (
@@ -24,14 +30,14 @@ export function StreakSection({
       </Title>
       <SectionContainer className="flex w-full flex-col gap-4">
         <div className="overflow-x-auto">
-          <ContributionGrid data={[]} />
+          <ContributionGrid data={streakData ?? []} />
         </div>
         <div className="flex w-full items-center justify-between gap-4">
           <div className="flex w-full flex-col gap-2 p-4">
             <div className="flex w-full items-center gap-2">
               <Label className="text-gray-700">누적</Label>
               <Label size="sm" className="text-primary-100">
-                2025.01.21 시작
+                {DateUtil.formatDateWithDots(streakStartAt ?? '')} 시작
               </Label>
             </div>
             <div className="flex w-full items-center gap-2">

--- a/apps/intra/src/features/member/components/streak-section/index.tsx
+++ b/apps/intra/src/features/member/components/streak-section/index.tsx
@@ -15,10 +15,13 @@ export function StreakSection({
 }: StreakSectionProps): React.ReactElement {
   return (
     <div className={cn('flex w-full min-w-0 flex-col gap-4', className)}>
-      <Title size="sm" weight="bold" className="mb-4">
+      <Title size="sm" weight="bold" className="mb-4 hidden md:block">
         스트릭
       </Title>
 
+      <Title size="xs" weight="bold" className="mb-4 md:hidden">
+        스트릭
+      </Title>
       <SectionContainer className="flex w-full flex-col gap-4">
         <div className="overflow-x-auto">
           <ContributionGrid data={[]} />

--- a/apps/intra/src/features/member/hooks/page/use-my-page-state.ts
+++ b/apps/intra/src/features/member/hooks/page/use-my-page-state.ts
@@ -2,12 +2,10 @@ import { useUpdateMyIntroduction } from '@/features/member/hooks/mutation/use-up
 import { useMyProfileData } from '@/features/member/hooks/query/use-my-page-data';
 import { useAuthStore } from '@/shared/store/auth-store';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
 
 export function useMyPageState() {
   const router = useRouter();
   const { user } = useAuthStore();
-  const [hydrated, setHydrated] = useState(false);
 
   const {
     data: myPageData,
@@ -17,10 +15,6 @@ export function useMyPageState() {
 
   const updateMyIntroduction = useUpdateMyIntroduction();
 
-  useEffect(() => {
-    setHydrated(true);
-  }, []);
-
   const handleUpdateIntroduction = async (introduction: string): Promise<void> => {
     await updateMyIntroduction.mutateAsync(introduction);
   };
@@ -29,11 +23,10 @@ export function useMyPageState() {
     router.back();
   };
 
-  const isDataReady = hydrated && user && myPageData && !myPageDataLoading;
+  const isDataReady = user && myPageData && !myPageDataLoading;
 
   return {
     user,
-    hydrated,
     myPageData,
     myPageDataLoading,
     myPageDataError,

--- a/apps/intra/src/features/member/pages/member-detail-page/desktop-member-detail-page.tsx
+++ b/apps/intra/src/features/member/pages/member-detail-page/desktop-member-detail-page.tsx
@@ -59,7 +59,13 @@ export function DesktopMemberDetailPage({
               total={memberProfileData.rating?.totalScore ?? 0}
               today={memberProfileData.rating?.todayScore ?? 0}
             />
-            <StreakSection className="mt-6" />
+            <StreakSection
+              className="mt-6"
+              totalDays={memberProfileData?.streak?.currentTotalStreak}
+              currentSeasonDays={memberProfileData?.streak?.currentSeasonStreak}
+              streakStartAt={memberProfileData?.streak?.streakStartAt}
+              streakData={memberProfileData?.streak?.streakData ?? []}
+            />
           </>
         }
         right={<AwardSection awardList={memberProfileData.award ?? []} />}

--- a/apps/intra/src/features/member/pages/member-detail-page/mobile-member-detail-page.tsx
+++ b/apps/intra/src/features/member/pages/member-detail-page/mobile-member-detail-page.tsx
@@ -37,7 +37,7 @@ export function MobileMemberDetailPage({
   return (
     <FadeIn isVisible={!isLoading && !error}>
       <MyInfoSection
-        className="mt-5"
+        className="mt-10"
         isMe={false}
         bojHandle={memberProfileData?.bojHandle}
         name={memberProfileData?.name}
@@ -53,7 +53,13 @@ export function MobileMemberDetailPage({
         total={memberProfileData?.rating?.totalScore ?? 0}
         today={memberProfileData?.rating?.todayScore ?? 0}
       />
-      <StreakSection className="mt-4" />
+      <StreakSection
+        className="mt-4"
+        totalDays={memberProfileData?.streak?.currentTotalStreak}
+        currentSeasonDays={memberProfileData?.streak?.currentSeasonStreak}
+        streakStartAt={memberProfileData?.streak?.streakStartAt}
+        streakData={memberProfileData?.streak?.streakData ?? []}
+      />
       <AwardSection className="mt-4" awardList={memberProfileData?.award ?? []} />
     </FadeIn>
   );

--- a/apps/intra/src/features/member/pages/my-page/desktop-my-page.tsx
+++ b/apps/intra/src/features/member/pages/my-page/desktop-my-page.tsx
@@ -69,7 +69,13 @@ export function DesktopMyPage(): React.ReactElement {
               total={myPageData?.rating?.totalScore ?? 0}
               today={myPageData?.rating?.todayScore ?? 0}
             />
-            <StreakSection className="mt-6" />
+            <StreakSection
+              className="mt-6"
+              totalDays={myPageData?.streak?.currentTotalStreak}
+              currentSeasonDays={myPageData?.streak?.currentSeasonStreak}
+              streakStartAt={myPageData?.streak?.streakStartAt}
+              streakData={myPageData?.streak?.streakData ?? []}
+            />
           </>
         }
         right={<AwardSection awardList={myPageData?.award ?? []} isMe={true} />}

--- a/apps/intra/src/features/member/pages/my-page/desktop-my-page.tsx
+++ b/apps/intra/src/features/member/pages/my-page/desktop-my-page.tsx
@@ -11,7 +11,6 @@ import { BackButton, Divider, TwoColumnLayout, LoadingDots, FadeIn } from '@hiar
 export function DesktopMyPage(): React.ReactElement {
   const {
     user,
-    hydrated,
     myPageData,
     myPageDataLoading,
     myPageDataError,
@@ -19,14 +18,6 @@ export function DesktopMyPage(): React.ReactElement {
     handleUpdateIntroduction,
     handleBackClick,
   } = useMyPageState();
-
-  if (!hydrated) {
-    return (
-      <div className="flex min-h-[400px] items-center justify-center">
-        <LoadingDots />
-      </div>
-    );
-  }
 
   if (!user) {
     return (
@@ -60,6 +51,7 @@ export function DesktopMyPage(): React.ReactElement {
       <BackButton onClick={handleBackClick} />
       <MyInfoSection
         className="mt-5"
+        isMe={true}
         bojHandle={myPageData?.bojHandle}
         name={myPageData?.name}
         introduction={myPageData?.introduction}
@@ -80,7 +72,7 @@ export function DesktopMyPage(): React.ReactElement {
             <StreakSection className="mt-6" />
           </>
         }
-        right={<AwardSection awardList={myPageData?.award ?? []} />}
+        right={<AwardSection awardList={myPageData?.award ?? []} isMe={true} />}
       />
       <Divider variant="horizontal" size="full" className="mt-8 bg-gray-900" />
       <StudySection className="mt-8" />

--- a/apps/intra/src/features/member/pages/my-page/mobile-my-page.tsx
+++ b/apps/intra/src/features/member/pages/my-page/mobile-my-page.tsx
@@ -49,6 +49,7 @@ export function MobileMyPage(): React.ReactElement {
   return (
     <FadeIn isVisible={isDataReady ?? false}>
       <MyInfoSection
+        className="mt-10"
         isMe={true}
         bojHandle={myPageData?.bojHandle}
         name={myPageData?.name}
@@ -64,7 +65,13 @@ export function MobileMyPage(): React.ReactElement {
         total={myPageData?.rating?.totalScore ?? 0}
         today={myPageData?.rating?.todayScore ?? 0}
       />
-      <StreakSection className="mt-6" />
+      <StreakSection
+        className="mt-6"
+        totalDays={myPageData?.streak?.currentTotalStreak}
+        currentSeasonDays={myPageData?.streak?.currentSeasonStreak}
+        streakStartAt={myPageData?.streak?.streakStartAt}
+        streakData={myPageData?.streak?.streakData ?? []}
+      />
       <AwardSection className="mt-6" awardList={myPageData?.award ?? []} isMe={true} />
       <Divider variant="horizontal" size="full" className="mt-6 bg-gray-900" />
       <StudySection className="mt-6" />

--- a/apps/intra/src/features/member/pages/my-page/mobile-my-page.tsx
+++ b/apps/intra/src/features/member/pages/my-page/mobile-my-page.tsx
@@ -64,8 +64,8 @@ export function MobileMyPage(): React.ReactElement {
         total={myPageData?.rating?.totalScore ?? 0}
         today={myPageData?.rating?.todayScore ?? 0}
       />
-      <StreakSection className="mt-4" />
-      <AwardSection className="mt-4" awardList={myPageData?.award ?? []} isMe={true} />
+      <StreakSection className="mt-6" />
+      <AwardSection className="mt-6" awardList={myPageData?.award ?? []} isMe={true} />
       <Divider variant="horizontal" size="full" className="mt-6 bg-gray-900" />
       <StudySection className="mt-6" />
     </FadeIn>

--- a/apps/intra/src/features/member/pages/my-page/mobile-my-page.tsx
+++ b/apps/intra/src/features/member/pages/my-page/mobile-my-page.tsx
@@ -11,7 +11,6 @@ import { BackButton, Divider, LoadingDots, FadeIn } from '@hiarc-platform/ui';
 export function MobileMyPage(): React.ReactElement {
   const {
     user,
-    hydrated,
     myPageData,
     myPageDataLoading,
     myPageDataError,
@@ -19,14 +18,6 @@ export function MobileMyPage(): React.ReactElement {
     handleUpdateIntroduction,
     handleBackClick,
   } = useMyPageState();
-
-  if (!hydrated) {
-    return (
-      <div className="flex min-h-[400px] items-center justify-center">
-        <LoadingDots />
-      </div>
-    );
-  }
 
   if (!user) {
     return (
@@ -58,7 +49,7 @@ export function MobileMyPage(): React.ReactElement {
   return (
     <FadeIn isVisible={isDataReady ?? false}>
       <MyInfoSection
-        className="mt-5"
+        isMe={true}
         bojHandle={myPageData?.bojHandle}
         name={myPageData?.name}
         introduction={myPageData?.introduction}
@@ -74,7 +65,7 @@ export function MobileMyPage(): React.ReactElement {
         today={myPageData?.rating?.todayScore ?? 0}
       />
       <StreakSection className="mt-4" />
-      <AwardSection className="mt-4" awardList={myPageData?.award ?? []} />
+      <AwardSection className="mt-4" awardList={myPageData?.award ?? []} isMe={true} />
       <Divider variant="horizontal" size="full" className="mt-6 bg-gray-900" />
       <StudySection className="mt-6" />
     </FadeIn>

--- a/apps/intra/src/features/member/types/model/streak-data.ts
+++ b/apps/intra/src/features/member/types/model/streak-data.ts
@@ -1,51 +1,14 @@
-export interface StreakDataProps {
+export interface StreakData {
   date?: string | null;
   value?: boolean | null;
 }
 
-export class StreakData {
-  private readonly props: StreakDataProps;
-
-  constructor(props: StreakDataProps) {
-    this.props = props;
-  }
-
-  get date(): string | null {
-    return this.props.date ?? null;
-  }
-
-  get value(): boolean | null {
-    return this.props.value ?? null;
-  }
-
-  toJson(): any {
+export const StreakData = {
+  fromJson(json: unknown): StreakData {
+    const data = (json || {}) as Record<string, unknown>;
     return {
-      date: this.props.date,
-      value: this.props.value,
+      date: (data.date as string) || null,
+      value: (data.value as boolean) || null,
     };
-  }
-
-  static fromJson(json: any): StreakData {
-    return new StreakData({
-      date: json?.date ?? null,
-      value: json?.value ?? null,
-    });
-  }
-
-  copyWith(updates: Partial<StreakDataProps>): StreakData {
-    return new StreakData({
-      ...this.props,
-      ...updates,
-    });
-  }
-
-  equals(other?: StreakData): boolean {
-    return Boolean(other) && this.props.date === other?.props.date;
-  }
-
-  compareTo(other: StreakData): number {
-    const thisDate = this.props.date ? new Date(this.props.date).getTime() : 0;
-    const otherDate = other.props.date ? new Date(other.props.date).getTime() : 0;
-    return thisDate - otherDate;
-  }
-}
+  },
+};

--- a/apps/intra/src/features/member/types/model/streak.ts
+++ b/apps/intra/src/features/member/types/model/streak.ts
@@ -3,6 +3,9 @@ import { StreakData } from './streak-data';
 export interface Streak {
   today?: string | null;
   streakData?: StreakData[] | null;
+  streakStartAt?: string;
+  currentTotalStreak?: number;
+  currentSeasonStreak?: number;
 }
 
 export const Streak = {
@@ -13,6 +16,9 @@ export const Streak = {
       streakData: data.streakData
         ? (data.streakData as unknown[]).map((data: unknown) => StreakData.fromJson(data))
         : null,
+      streakStartAt: (data.streakStartAt as string) || '',
+      currentTotalStreak: (data.currentTotalStreak as number) || 0,
+      currentSeasonStreak: (data.currentSeasonStreak as number) || 0,
     };
   },
 };

--- a/apps/intra/src/shared/components/ui/ConditionalHeaderClient.tsx
+++ b/apps/intra/src/shared/components/ui/ConditionalHeaderClient.tsx
@@ -26,6 +26,8 @@ export function ConditionalHeaderClient({
     pathname !== '/announcement';
 
   const isStudy = pathname.includes('/study');
+  const isMyPage = pathname === '/my';
+  const isMemberDetail = pathname.startsWith('/member/') && pathname !== '/member';
 
   const handleBackClick = (): void => {
     router.back();
@@ -51,13 +53,15 @@ export function ConditionalHeaderClient({
     },
   ];
 
-  // 모바일에서 공지사항 관련 페이지인 경우 MobileHeader 사용
+  // 모바일에서 특정 페이지인 경우 MobileHeader 사용
   if (
     isAnnouncementList ||
     isAnnouncementWrite ||
     isAnnouncementEdit ||
     isAnnouncementDetail ||
-    isStudy
+    isStudy ||
+    isMyPage ||
+    isMemberDetail
   ) {
     const getTitle = (): string => {
       if (isAnnouncementList) {
@@ -74,6 +78,12 @@ export function ConditionalHeaderClient({
       }
       if (isStudy) {
         return '스터디';
+      }
+      if (isMyPage) {
+        return '마이페이지';
+      }
+      if (isMemberDetail) {
+        return '학회원 정보';
       }
       return '공지사항';
     };

--- a/apps/intra/src/shared/components/ui/header/desktop-header.tsx
+++ b/apps/intra/src/shared/components/ui/header/desktop-header.tsx
@@ -122,8 +122,7 @@ export function DesktopHeader({
         <Input
           type="search"
           variant="search"
-          // placeholder={isAuthenticated ? 'BOJ 핸들명을 입력하세요' : '로그인 후 검색 가능합니다'}
-          placeholder="기능 준비 중 입니다"
+          placeholder={isAuthenticated ? 'BOJ 핸들명을 입력하세요' : '로그인 후 검색 가능합니다'}
           className="h-[44px] w-[328px]"
           value={searchInput}
           onChange={(event) => setSearchInput(event.target.value)}
@@ -132,8 +131,7 @@ export function DesktopHeader({
               handleSearch(searchInput);
             }
           }}
-          // disabled={!isAuthenticated || isFetching}
-          disabled
+          disabled={!isAuthenticated || isFetching}
         />
         {isAuthenticated ? (
           <AuthenticatedUserSection />

--- a/apps/intra/src/shared/components/ui/header/mobile-header.tsx
+++ b/apps/intra/src/shared/components/ui/header/mobile-header.tsx
@@ -80,8 +80,7 @@ export function MobileHeader({
           <Input
             type="search"
             variant="search"
-            // placeholder={isAuthenticated ? 'BOJ 핸들명을 입력하세요' : '로그인 후 검색 가능합니다'}
-            placeholder="기능 준비 중 입니다"
+            placeholder={isAuthenticated ? 'BOJ 핸들명을 입력하세요' : '로그인 후 검색 가능합니다'}
             className="mx-4 h-[44px] flex-1 text-base"
             autoFocus
             value={searchInput}
@@ -91,8 +90,7 @@ export function MobileHeader({
                 handleSearch(searchInput);
               }
             }}
-            // disabled={!isAuthenticated || isFetching}
-            disabled
+            disabled={!isAuthenticated || isFetching}
           />
           <IconButton
             iconSrc="/shared-assets/Close.svg"
@@ -136,10 +134,9 @@ export function MobileHeader({
               <div className="flex items-center gap-2 border-b border-gray-200 px-5 py-2">
                 <Input
                   variant="search"
-                  // placeholder={
-                  //   isAuthenticated ? 'BOJ 핸들명을 입력하세요' : '로그인 후 검색 가능합니다'
-                  // }
-                  placeholder="기능 준비 중 입니다"
+                  placeholder={
+                    isAuthenticated ? 'BOJ 핸들명을 입력하세요' : '로그인 후 검색 가능합니다'
+                  }
                   className="flex-1 text-base"
                   value={searchInput}
                   onChange={(event) => setSearchInput(event.target.value)}
@@ -148,8 +145,7 @@ export function MobileHeader({
                       handleSearch(searchInput);
                     }
                   }}
-                  // disabled={!isAuthenticated || isFetching}
-                  disabled
+                  disabled={!isAuthenticated || isFetching}
                 />
                 <IconButton
                   iconSrc="/shared-assets/Close.svg"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,7 @@ module.exports = {
   darkMode: ['class', '.dark'],
   safelist: [
     // 특수한 클래스들 (패턴으로 매칭하기 어려운것들)
+    'bg-primary-100/50',
     'min-w-0',
     'w-[1200px]',
     'max-w-[1200px]',


### PR DESCRIPTION
## 🔀 PR 개요
회원 프로필 및 통계 페이지를 리팩토링하고 개선하여 UI 컴포넌트 모듈화, 데스크톱과 모바일 반응형 향상
하이팅 섹션을 전용 데스크톱 및 모바일 컴포넌트로 분리, 새로운 데이터 형식을 처리하도록 연속 기록 섹션 업데이트, 더 나은 레이아웃과 자동 스크롤 동작으로 사용자 경험 개선

<br/>

## 📌 주요 변경 사항
- 다양한 기기에 최적화된 레이아웃을 위해 `HitingSection`을 `DesktopHitingSection`과 `MobileHitingSection`으로 분리
- 새로운 연속 기록 데이터 형식(`StreakData`) 처리 및 이진 연속 기록 색상 로직으로 `ContributionGrid` 리팩토링
- 반응형 제목과 레이아웃 사용으로 `AwardSection` 및 `StreakSection` 컴포넌트 업데이트
- 최신 연속 기록 항목으로 자동 스크롤 구현
- 사용하지 않는 하이드레이션 로직 제거로 코드 정리 및 최적화

<br/>

## 📝 작업 상세 내용
**UI 컴포넌트 리팩토링 및 반응형**
- 다양한 기기에서 최적화된 레이아웃을 위해 `HitingSection`을 `DesktopHitingSection`과 `MobileHitingSection` 컴포넌트로 분리하고, 화면 크기에 따라 적절한 버전을 렌더링하도록 메인 섹션 업데이트
- 모바일과 데스크톱 표시를 개선하기 위해 반응형 제목과 레이아웃을 사용하도록 `AwardSection`과 `StreakSection` 컴포넌트 업데이트

**연속 기록 추적 로직 및 데이터 처리**
- 새로운 연속 기록 데이터 형식(`StreakData`)을 처리하고, 색상 로직을 이진 연속 기록/비연속 기록으로 변경하며, 최신 연속 기록 항목으로 자동 스크롤을 구현하도록 `ContributionGrid` 리팩토링
- 연속 기록 통계와 시작 날짜의 올바른 표시를 보장하기 위해 회원 프로필 페이지에서 `StreakSection`으로 연속 기록 데이터가 전달되는 방식 업데이트

**코드 정리 및 최적화**
- 데이터 준비 상태 확인을 간소화하기 위해 `use-my-page-state`에서 사용하지 않는 하이드레이션 로직 및 관련 상태 제거
- 유지보수성 향상을 위해 여러 컴포넌트에서 임포트 정리 및 사용하지 않는 코드 제거

**레이아웃 및 사용자 경험 개선**
- 더 일관된 모양을 위해 모바일 회원 상세 페이지 및 기타 섹션의 간격과 레이아웃 개선
- 임시 기능 비활성화 메시지를 제거하고 회원 페이지 컴포넌트를 적절히 렌더링하도록 `my/page.tsx`의 오류 다이얼로그 로직 업데이트

<br/>

## 🔗 관련 이슈/PR
- #133

<br/>

## 💬 기타 참고사항