### PR TITLE
Refactor: 공지사항 목록을 등급 이벤트 분리로 리팩토링

### DIFF
--- a/apps/intra/src/features/main/components/announcement-list-section/announcement-list-item.tsx
+++ b/apps/intra/src/features/main/components/announcement-list-section/announcement-list-item.tsx
@@ -7,6 +7,7 @@ interface AnnouncementListItemProps {
   category: 'RATING' | 'STUDY' | 'ETC' | 'GENERAL' | 'EXTERNAL';
   date?: string;
   className?: string;
+  isEvent?: boolean;
 }
 
 export function AnnouncementListItem({
@@ -15,33 +16,40 @@ export function AnnouncementListItem({
   category,
   date,
   className,
+  isEvent = false,
 }: AnnouncementListItemProps): React.ReactElement {
   const router = useRouter();
   return (
     <div
-      onClick={() => {
-        router.push(`/announcement/${announcementId}`);
-      }}
+      onClick={!isEvent ? () => router.push(`/announcement/${announcementId}`) : undefined}
       className={cn(
         'flex w-full gap-2 border-b border-gray-200 p-3',
-        'cursor-pointer transition-colors duration-200 hover:bg-gray-50',
+        !isEvent && 'cursor-pointer transition-colors duration-200 hover:bg-gray-50',
         className
       )}
     >
       <div className="w-20 flex-shrink-0">
         <CategoryChip category={category} />
       </div>
-      <div className="flex w-full min-w-0 flex-grow cursor-pointer items-center justify-between">
+      <div
+        className={cn(
+          'flex w-full min-w-0 flex-grow items-center justify-between',
+          !isEvent && 'cursor-pointer'
+        )}
+      >
         <Label
           size="md"
           weight={category === 'RATING' ? 'bold' : 'regular'}
-          className="min-w-0 cursor-pointer truncate"
+          className={cn('min-w-0 truncate', !isEvent && 'cursor-pointer')}
         >
           {title}
         </Label>
         <Label
           size="sm"
-          className="ml-2 flex-shrink-0 cursor-pointer whitespace-nowrap text-gray-700"
+          className={cn(
+            'ml-2 flex-shrink-0 whitespace-nowrap text-gray-700',
+            !isEvent && 'cursor-pointer'
+          )}
         >
           {date}
         </Label>

--- a/apps/intra/src/features/main/components/announcement-list-section/index.tsx
+++ b/apps/intra/src/features/main/components/announcement-list-section/index.tsx
@@ -24,17 +24,9 @@ export function AnnouncementListSection({
   const { data: upcomingSchedule } = useUpcomingSchedule();
   const { data: externalAnnouncements } = useExternalSchedule();
 
-  const sortedUpcomingSchedules = upcomingSchedule?.schedules
-    ? [...upcomingSchedule.schedules].sort((first, second) => {
-        if (first.announcementType === 'RATING' && second.announcementType !== 'RATING') {
-          return -1;
-        }
-        if (first.announcementType !== 'RATING' && second.announcementType === 'RATING') {
-          return 1;
-        }
-        return 0;
-      })
-    : [];
+  // Rating 데이터 사용
+  const ratingData = upcomingSchedule?.rating;
+  const regularSchedules = upcomingSchedule?.schedules || [];
 
   return (
     <div className={cn('w-full', className)}>
@@ -50,29 +42,62 @@ export function AnnouncementListSection({
       </div>
 
       <Divider variant="horizontal" size="full" className="mt-4" />
-      <div className="h-[350px] overflow-y-auto">
-        {tab === 'announcement' && (
-          <SlideFade key="announcement">
-            <div>
-              {sortedUpcomingSchedules.map((announcement: Schedule, index: number) => (
-                <AnnouncementListItem
-                  key={announcement.announcementId || index}
-                  announcementId={announcement.announcementId || 0}
-                  title={announcement.scheduleTitle || '제목 없음'}
-                  date={
-                    announcement.announcementType === 'RATING'
-                      ? ''
-                      : announcement.scheduledAt
-                        ? new Date(announcement.scheduledAt).toLocaleDateString()
-                        : new Date(announcement.createdAt ?? '').toLocaleDateString()
-                  }
-                  category={announcement.announcementType || 'GENERAL'}
-                />
-              ))}
+
+      {tab === 'announcement' ? (
+        <div className="flex h-[350px] flex-col">
+          {/* Rating 고정 영역 */}
+          {ratingData && (
+            <div className="flex-shrink-0">
+              <SlideFade key="rating-section">
+                <div>
+                  <AnnouncementListItem
+                    isEvent={true}
+                    key="rating-season"
+                    announcementId={0}
+                    title={ratingData.season.title}
+                    date={ratingData.season.startDateTime.toLocaleDateString()}
+                    category="RATING"
+                  />
+                  {ratingData.event.title && (
+                    <AnnouncementListItem
+                      isEvent={true}
+                      key="rating-event"
+                      announcementId={0}
+                      title={ratingData.event.title}
+                      date={ratingData.event.startDateTime.toLocaleDateString()}
+                      category="RATING"
+                    />
+                  )}
+                </div>
+              </SlideFade>
             </div>
-          </SlideFade>
-        )}
-        {tab === 'algorithm-news' && (
+          )}
+
+          {/* 일반 스케줄 스크롤 영역 */}
+          {regularSchedules.length > 0 && (
+            <div className="flex-1 overflow-y-auto">
+              <SlideFade key="regular-schedules">
+                <div>
+                  {regularSchedules.map((announcement: Schedule, index: number) => (
+                    <AnnouncementListItem
+                      key={announcement.announcementId || index}
+                      announcementId={announcement.announcementId || 0}
+                      title={announcement.scheduleTitle || '제목 없음'}
+                      date={
+                        announcement.scheduledAt
+                          ? new Date(announcement.scheduledAt).toLocaleDateString()
+                          : new Date(announcement.createdAt ?? '').toLocaleDateString()
+                      }
+                      category={announcement.announcementType || 'GENERAL'}
+                    />
+                  ))}
+                </div>
+              </SlideFade>
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="h-[350px] overflow-y-auto">
           <SlideFade key="algorithm-news">
             <div>
               {externalAnnouncements &&
@@ -91,8 +116,8 @@ export function AnnouncementListSection({
                 ))}
             </div>
           </SlideFade>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 🔀 PR 개요
공지사항 목록 섹션을 리팩토링하여 레이팅 관련 공지사항과 일반 일정을 더 잘 분리하고 표시하도록 개선
공지사항 목록 항목의 유형에 따른 동작 및 스타일링을 업데이트하고, 레이팅 공지사항 전용 영역 도입, 이벤트 항목의 클릭 및 커서 동작 업데이트, 일정 정렬 로직 간소화

<br/>

## 📌 주요 변경 사항
- 레이팅 시즌 및 이벤트 공지사항을 위한 상단 고정 섹션 추가
- 일반 일정을 스크롤 가능한 하단 영역으로 분리 표시
- 이벤트 항목과 일반 클릭 가능한 공지사항을 구분하는 새로운 `isEvent` prop 추가
- 이벤트 항목의 네비게이션 및 포인터 커서 스타일링 비활성화
- 레이팅 공지사항 우선순위를 위한 기존 정렬 로직 제거

<br/>

## 📝 작업 상세 내용
**공지사항 표시 리팩토링**
- 레이팅 관련 정보의 가시성과 구성을 개선하기 위해 공지사항 목록에 레이팅 시즌 및 이벤트 공지사항(`ratingData`)을 위한 상단 고정 섹션 추가하여 일반 일정과 분리 표시
- 일반 일정을 레이팅 섹션 아래 스크롤 가능한 영역에 표시하고, 레이팅 공지사항을 우선순위로 하는 기존 정렬 로직 제거

**공지사항 항목 동작 및 스타일링**
- 이벤트 항목(레이팅 공지사항 등)을 일반 클릭 가능한 공지사항과 구분하기 위해 `AnnouncementListItem`에 새로운 `isEvent` prop 추가
- `isEvent`가 true일 때 이벤트 항목이 클릭할 수 없도록 네비게이션 및 커서 포인터 스타일링을 비활성화하고 적절한 시각적 단서 제공

**일반 UI 개선**
- 명확성과 유지보수성을 위해 탭 전환 로직 및 조건부 렌더링 업데이트, 공지사항과 알고리즘 뉴스 섹션 간 분리 개선

<br/>

## 🔗 관련 이슈/PR
- #138

<br/>

## 💬 기타 참고사항