### PR TITLE
Feat: 인트라 페이지 전반 수정

### DIFF
--- a/apps/intra/src/app/signup/page.tsx
+++ b/apps/intra/src/app/signup/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { PageLayout } from '@hiarc-platform/ui';
+import { Label, PageLayout } from '@hiarc-platform/ui';
 import { DesktopSignupPage, MobileSignupPage } from '@/features/auth/pages/signup';
 import { useCurrentSemester } from '@/features/semester/hooks/use-current-semester';
 
@@ -10,7 +10,9 @@ export default function SignUpPage(): React.ReactElement {
   if (!currentSemesterData?.recruitingSemester) {
     return (
       <div className="flex min-h-screen items-center justify-center">
-        <p className="text-lg text-gray-600">모집 중이 아닙니다.</p>
+        <Label size="lg" className="text-gray-600">
+          모집 중이 아닙니다.
+        </Label>
       </div>
     );
   }

--- a/apps/intra/src/features/auth/components/boj-guide-button/boj-guide-dialog.tsx
+++ b/apps/intra/src/features/auth/components/boj-guide-button/boj-guide-dialog.tsx
@@ -61,13 +61,18 @@ export function BojGuideDialog({ showBackground = true }: BojGuideDialogProps): 
               </Button>
             </div>
             <div>
-              <div className="mb-2 flex">
-                <Label size="lg" weight="regular" className="mr-2">
-                  2.
-                </Label>
-                <Label size="lg" weight="regular">
-                  백준 사이트에 가입한 후, 소속 학교를 &#39;홍익대학교&#39;로 설정해주세요. 학회
-                  활동 시 활용될 예정입니다.
+              <div className="flex flex-col">
+                <div className="mb-2 flex">
+                  <Label size="lg" weight="regular" className="mr-2">
+                    2.
+                  </Label>
+                  <Label size="lg" weight="regular">
+                    백준 사이트에 가입한 후, 소속 학교를 &#39;홍익대학교&#39;로 설정해주세요. 학회
+                    활동 시 활용될 예정입니다.
+                  </Label>
+                </div>
+                <Label size="sm" weight="regular" className="mb-2 text-gray-500">
+                  {'* solved.ac > 프로필 > 강제 정보 갱신 과정이 필요할 수 있습니다.'}
                 </Label>
               </div>
               <Button
@@ -90,6 +95,7 @@ export function BojGuideDialog({ showBackground = true }: BojGuideDialogProps): 
                 />
               </Button>
             </div>
+
             <div>
               <div className="mb-2 flex">
                 <Label size="lg" weight="regular" className="mr-2">

--- a/apps/intra/src/features/auth/components/dialog/greeting-dialog.tsx
+++ b/apps/intra/src/features/auth/components/dialog/greeting-dialog.tsx
@@ -8,7 +8,7 @@ import {
   DialogUtil,
   Label,
 } from '@hiarc-platform/ui';
-import React from 'react';
+import React, { useState } from 'react';
 
 interface GreetingDialogProps {
   title: string;
@@ -23,6 +23,8 @@ export function GreetingDialog({
   showBackground = true,
   onConfirm,
 }: GreetingDialogProps): React.ReactElement {
+  const [copiedAccount, setCopiedAccount] = useState<string | null>(null);
+
   const handleConfirm = async (): Promise<void> => {
     DialogUtil.hideAllDialogs();
     onConfirm?.();
@@ -32,10 +34,28 @@ export function GreetingDialog({
     DialogUtil.hideAllDialogs();
   };
 
+  const extractAccountNumber = (text: string): string | null => {
+    const accountPattern = /\b\d{8,}\b|\d[0-9,-]{3,6}-[0-9,-]{2,6}-[0-9,-]/;
+    const match = text.match(accountPattern);
+    return match ? match[0] : null;
+  };
+
+  const handleCopyAccount = async (accountNumber: string): Promise<void> => {
+    try {
+      await navigator.clipboard.writeText(accountNumber);
+      setCopiedAccount(accountNumber);
+      setTimeout(() => setCopiedAccount(null), 2000);
+    } catch (error) {
+      console.error('Failed to copy account number:', error);
+    }
+  };
+
+  const accountNumber = extractAccountNumber(message);
+
   return (
     <Dialog open={true} onOpenChange={(open) => !open && handleCancel()}>
       <DialogContent className="sm:max-w-[380px]" showBackground={showBackground}>
-        <DialogHeader className="mb-6">
+        <DialogHeader className="mb-6 text-left">
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>
         <DialogDescription asChild>
@@ -48,6 +68,18 @@ export function GreetingDialog({
             ))}
           </Label>
         </DialogDescription>
+        {accountNumber && (
+          <div className="mt-4 flex justify-end">
+            <Button
+              variant="line"
+              size="xs"
+              onClick={() => handleCopyAccount(accountNumber)}
+              className="px-2 text-xs"
+            >
+              {copiedAccount === accountNumber ? '복사됨' : '계좌번호 복사'}
+            </Button>
+          </div>
+        )}
         <Button className="mt-6 w-full" onClick={handleConfirm}>
           <Label size="md">확인</Label>
         </Button>

--- a/apps/intra/src/features/main/components/announcement-list-section/AnnouncementListSection.tsx
+++ b/apps/intra/src/features/main/components/announcement-list-section/AnnouncementListSection.tsx
@@ -53,11 +53,13 @@ export function AnnouncementListSection({
             <div className="flex-shrink-0">
               <SlideFade key="rating-section">
                 <div>
-                  <RatingListItem
-                    key="rating-season"
-                    title={`${ratingData.season.title} : ${DateUtil.formatKoreanDate(ratingData.season.startDateTime)} ~ ${DateUtil.formatKoreanDate(ratingData.season.endDateTime)}`}
-                    category="RATING"
-                  />
+                  {ratingData.season.title && (
+                    <RatingListItem
+                      key="rating-season"
+                      title={`${ratingData.season.title} : ${DateUtil.formatKoreanDate(ratingData.season.startDateTime)} ~ ${DateUtil.formatKoreanDate(ratingData.season.endDateTime)}`}
+                      category="RATING"
+                    />
+                  )}
                   {ratingData.event.title && (
                     <RatingListItem
                       key="rating-event"

--- a/apps/intra/src/features/member/components/hiting-section/desktop-hiting-section.tsx
+++ b/apps/intra/src/features/member/components/hiting-section/desktop-hiting-section.tsx
@@ -43,7 +43,7 @@ export function DesktopHitingSection({
                 key={index}
                 name={record.description ?? ''}
                 rank={record.ranking ?? 0}
-                div={'DIV_1'}
+                div={record.division ?? 'DIV_1'}
               />
             ))}
           </div>

--- a/apps/intra/src/features/member/components/hiting-section/mobile-hiting-section.tsx
+++ b/apps/intra/src/features/member/components/hiting-section/mobile-hiting-section.tsx
@@ -56,7 +56,7 @@ export function MobileHitingSection({
                 key={index}
                 name={record.description ?? ''}
                 rank={record.ranking ?? 0}
-                div={'DIV_1'}
+                div={record.division ?? 'DIV_1'}
               />
             ))}
           </div>

--- a/apps/intra/src/features/member/components/my-info-section/index.tsx
+++ b/apps/intra/src/features/member/components/my-info-section/index.tsx
@@ -1,40 +1,28 @@
-import {
-  cn,
-  DialogUtil,
-  IconButton,
-  Label,
-  RatingChip,
-  RatingChipProps,
-  Title,
-} from '@hiarc-platform/ui';
+import { cn, DialogUtil, IconButton, Label, RatingChip, Title } from '@hiarc-platform/ui';
 import React from 'react';
 import { MyInfoDialog } from './my-info-dialog';
+import { MemberProfile } from '../../types/model/member-profile';
+import { useAuthStore } from '@/shared/store/auth-store';
 
 interface MyInfoSectionProps {
-  name?: string | null;
-  bojHandle?: string | null;
-  introduction?: string | null;
-  rating?: RatingChipProps['rating'];
-  div?: RatingChipProps['rating'];
   className?: string;
   isMe?: boolean;
+  memberProfileData?: MemberProfile;
   onSave?(introduction: string): Promise<void>;
 }
 
 export function MyInfoSection({
   className,
-  introduction,
-  name,
-  bojHandle,
   onSave,
-  rating,
-  div,
   isMe,
+  memberProfileData,
 }: MyInfoSectionProps): React.ReactElement {
+  const { user } = useAuthStore();
+
   const handleOpenDialog = (): void => {
     DialogUtil.showComponent(
       <MyInfoDialog
-        initialValue={introduction || ''}
+        initialValue={memberProfileData?.introduction || ''}
         onSave={onSave}
         onCancel={() => {
           console.log('My info dialog cancelled');
@@ -44,8 +32,8 @@ export function MyInfoSection({
   };
 
   const handleBojHandleClick = (): void => {
-    if (bojHandle) {
-      window.open(`https://solved.ac/profile/${bojHandle}`, '_blank');
+    if (memberProfileData?.bojHandle) {
+      window.open(`https://solved.ac/profile/${memberProfileData?.bojHandle}`, '_blank');
     }
   };
 
@@ -61,13 +49,15 @@ export function MyInfoSection({
               className="cursor-pointer"
               onClick={handleBojHandleClick}
             >
-              {bojHandle}
+              {memberProfileData?.bojHandle}
             </Title>
             <Title size="sm" weight="semibold" disableAnimation={true} className="text-gray-500">
-              ({name})
+              ({memberProfileData?.name})
             </Title>
-            <RatingChip rating={rating} />
-            <RatingChip rating={div} />
+            <RatingChip rating={memberProfileData?.tier ?? 'UNRATED'} />
+            {isMe && user?.memberRole === 'ASSOCIATE' ? null : (
+              <RatingChip rating={memberProfileData?.division ?? 'UNRATED'} />
+            )}
           </div>
           {isMe && (
             <IconButton
@@ -77,8 +67,8 @@ export function MyInfoSection({
             />
           )}
         </div>
-        <Label className={cn(!introduction ? 'text-gray-500' : 'text-gray-900')}>
-          {introduction ?? '자기소개가 없습니다.'}
+        <Label className={cn(!memberProfileData?.introduction ? 'text-gray-500' : 'text-gray-900')}>
+          {memberProfileData?.introduction ?? '자기소개가 없습니다.'}
         </Label>
       </div>
     </div>

--- a/apps/intra/src/features/member/pages/member-detail-page/desktop-member-detail-page.tsx
+++ b/apps/intra/src/features/member/pages/member-detail-page/desktop-member-detail-page.tsx
@@ -39,15 +39,7 @@ export function DesktopMemberDetailPage({
   return (
     <FadeIn isVisible={isLoading || error ? false : true}>
       <BackButton onClick={onBackClick} />
-      <MyInfoSection
-        className="mt-5"
-        isMe={false}
-        bojHandle={memberProfileData.bojHandle}
-        name={memberProfileData.name}
-        introduction={memberProfileData.introduction}
-        rating={memberProfileData.tier ?? 'UNRATED'}
-        div={memberProfileData.division ?? 'UNRATED'}
-      />
+      <MyInfoSection className="mt-5" isMe={false} memberProfileData={memberProfileData} />
       <Divider variant="horizontal" size="full" className="mt-4 bg-gray-900" />
       <TwoColumnLayout
         className="mt-8"

--- a/apps/intra/src/features/member/pages/member-detail-page/desktop-member-detail-page.tsx
+++ b/apps/intra/src/features/member/pages/member-detail-page/desktop-member-detail-page.tsx
@@ -58,6 +58,7 @@ export function DesktopMemberDetailPage({
               season={memberProfileData.rating?.seasonScore ?? 0}
               total={memberProfileData.rating?.totalScore ?? 0}
               today={memberProfileData.rating?.todayScore ?? 0}
+              ratingRecords={memberProfileData?.rating?.records ?? []}
             />
             <StreakSection
               className="mt-6"

--- a/apps/intra/src/features/member/pages/member-detail-page/mobile-member-detail-page.tsx
+++ b/apps/intra/src/features/member/pages/member-detail-page/mobile-member-detail-page.tsx
@@ -52,6 +52,7 @@ export function MobileMemberDetailPage({
         season={memberProfileData?.rating?.seasonScore ?? 0}
         total={memberProfileData?.rating?.totalScore ?? 0}
         today={memberProfileData?.rating?.todayScore ?? 0}
+        ratingRecords={memberProfileData?.rating?.records ?? []}
       />
       <StreakSection
         className="mt-4"

--- a/apps/intra/src/features/member/pages/member-detail-page/mobile-member-detail-page.tsx
+++ b/apps/intra/src/features/member/pages/member-detail-page/mobile-member-detail-page.tsx
@@ -4,7 +4,7 @@ import { AwardSection } from '@/features/award/components/award-section';
 import { HitingSection } from '@/features/member/components/hiting-section';
 import { MyInfoSection } from '@/features/member/components/my-info-section';
 import { StreakSection } from '@/features/member/components/streak-section';
-import { Divider, LoadingDots, FadeIn } from '@hiarc-platform/ui';
+import { Divider, LoadingDots, FadeIn, Label } from '@hiarc-platform/ui';
 import { MemberProfile } from '../../types/model/member-profile';
 
 interface MobileMemberDetailPageProps {
@@ -27,24 +27,20 @@ export function MobileMemberDetailPage({
   }
 
   if (error !== null) {
-    return <div>Error loading member profile</div>;
-  }
-
-  if (!memberProfileData) {
-    return <div>No member profile data available</div>;
+    return (
+      <div className="mt-20 flex min-h-[400px] items-center justify-center">
+        <div className="text-center">
+          <Label size="lg" className=" text-gray-600">
+            문제가 발생했습니다.
+          </Label>
+        </div>
+      </div>
+    );
   }
 
   return (
     <FadeIn isVisible={!isLoading && !error}>
-      <MyInfoSection
-        className="mt-10"
-        isMe={false}
-        bojHandle={memberProfileData?.bojHandle}
-        name={memberProfileData?.name}
-        introduction={memberProfileData?.introduction}
-        rating={memberProfileData?.tier ?? 'UNRATED'}
-        div={memberProfileData?.division ?? 'UNRATED'}
-      />
+      <MyInfoSection className="mt-10" isMe={false} memberProfileData={memberProfileData} />
       <Divider variant="horizontal" size="full" className="mt-4 bg-gray-900" />
       <HitingSection
         className="mt-6"

--- a/apps/intra/src/features/member/pages/my-page/desktop-my-page.tsx
+++ b/apps/intra/src/features/member/pages/my-page/desktop-my-page.tsx
@@ -68,6 +68,7 @@ export function DesktopMyPage(): React.ReactElement {
               season={myPageData?.rating?.seasonScore ?? 0}
               total={myPageData?.rating?.totalScore ?? 0}
               today={myPageData?.rating?.todayScore ?? 0}
+              ratingRecords={myPageData?.rating?.records ?? []}
             />
             <StreakSection
               className="mt-6"

--- a/apps/intra/src/features/member/pages/my-page/desktop-my-page.tsx
+++ b/apps/intra/src/features/member/pages/my-page/desktop-my-page.tsx
@@ -52,12 +52,8 @@ export function DesktopMyPage(): React.ReactElement {
       <MyInfoSection
         className="mt-5"
         isMe={true}
-        bojHandle={myPageData?.bojHandle}
-        name={myPageData?.name}
-        introduction={myPageData?.introduction}
+        memberProfileData={myPageData}
         onSave={handleUpdateIntroduction}
-        rating={myPageData?.tier ?? 'UNRATED'}
-        div={myPageData?.division ?? 'UNRATED'}
       />
       <Divider variant="horizontal" size="full" className="mt-4 bg-gray-900" />
       <TwoColumnLayout

--- a/apps/intra/src/features/member/pages/my-page/mobile-my-page.tsx
+++ b/apps/intra/src/features/member/pages/my-page/mobile-my-page.tsx
@@ -6,7 +6,7 @@ import { MyInfoSection } from '@/features/member/components/my-info-section';
 import { StreakSection } from '@/features/member/components/streak-section';
 import { StudySection } from '@/features/member/components/study-section';
 import { useMyPageState } from '@/features/member/hooks/page/use-my-page-state';
-import { BackButton, Divider, LoadingDots, FadeIn } from '@hiarc-platform/ui';
+import { Divider, LoadingDots, FadeIn, Label } from '@hiarc-platform/ui';
 
 export function MobileMyPage(): React.ReactElement {
   const {
@@ -16,7 +16,6 @@ export function MobileMyPage(): React.ReactElement {
     myPageDataError,
     isDataReady,
     handleUpdateIntroduction,
-    handleBackClick,
   } = useMyPageState();
 
   if (!user) {
@@ -37,10 +36,11 @@ export function MobileMyPage(): React.ReactElement {
 
   if (myPageDataError) {
     return (
-      <div className="flex min-h-[400px] items-center justify-center">
+      <div className="mt-20 flex min-h-[400px] items-center justify-center">
         <div className="text-center">
-          <p className="mb-4 text-lg text-gray-600">문제가 발생했습니다.</p>
-          <BackButton onClick={handleBackClick} />
+          <Label size="lg" className=" text-gray-600">
+            문제가 발생했습니다.
+          </Label>
         </div>
       </div>
     );
@@ -51,12 +51,8 @@ export function MobileMyPage(): React.ReactElement {
       <MyInfoSection
         className="mt-10"
         isMe={true}
-        bojHandle={myPageData?.bojHandle}
-        name={myPageData?.name}
-        introduction={myPageData?.introduction}
+        memberProfileData={myPageData}
         onSave={handleUpdateIntroduction}
-        rating={myPageData?.tier ?? 'UNRATED'}
-        div={myPageData?.division ?? 'UNRATED'}
       />
       <Divider variant="horizontal" size="full" className="mt-4 bg-gray-900" />
       <HitingSection

--- a/apps/intra/src/features/member/pages/my-page/mobile-my-page.tsx
+++ b/apps/intra/src/features/member/pages/my-page/mobile-my-page.tsx
@@ -64,6 +64,7 @@ export function MobileMyPage(): React.ReactElement {
         season={myPageData?.rating?.seasonScore ?? 0}
         total={myPageData?.rating?.totalScore ?? 0}
         today={myPageData?.rating?.todayScore ?? 0}
+        ratingRecords={myPageData?.rating?.records ?? []}
       />
       <StreakSection
         className="mt-6"

--- a/apps/intra/src/shared/components/ui/header/authenticated-user-section.tsx
+++ b/apps/intra/src/shared/components/ui/header/authenticated-user-section.tsx
@@ -39,7 +39,7 @@ export function AuthenticatedUserSection(): React.ReactElement {
       return;
     }
 
-    if (myInfo?.memberRole === 'GUEST' || myInfo?.memberRole === 'ASSOCIATE') {
+    if (myInfo?.memberRole === 'GUEST') {
       DialogUtil.showError('승인되지 않았습니다. 조금만 기다려주세요.');
       return;
     }
@@ -108,7 +108,7 @@ export function AuthenticatedUserSection(): React.ReactElement {
 
   // 커스텀 이벤트로 데스크톱-모바일 간 동기화
   useEffect(() => {
-    const handlePopupDismiss = () => {
+    const handlePopupDismiss = (): void => {
       setIsPopupOpen(false);
     };
 


### PR DESCRIPTION
## 🔀 PR 개요
여러 회원 프로필 컴포넌트를 통합된 `memberProfileData` prop을 사용하도록 리팩토링하여 데이터 처리를 간소화하고 prop 중복줄임
여러 페이지에서 일반 텍스트를 표준화된 `Label` 컴포넌트로 교체하여 UI 일관성을 개선
다이얼로그의 계좌번호 복사 버튼 및 더 유익한 오류 메시지를 포함한 새로운 기능과 오류 처리 개선사항 도입

<br/>

## 📌 주요 변경 사항
- 개별 props 대신 통합된 `memberProfileData` prop 사용으로 `MyInfoSection` 및 관련 컴포넌트 리팩토링
- 회원가입, 회원 상세, 마이 페이지 화면에서 일관된 룩앤필을 위해 일반 텍스트를 `Label` 컴포넌트로 교체
- 계좌번호 추출 및 복사 로직과 사용자 피드백을 포함한 `GreetingDialog`의 클립보드 복사 버튼 추가
- `HitingSection`에서 하드코딩된 division 값 버그 수정
- `ASSOCIATE` 사용자는 허용하고 `GUEST` 역할 사용자만 차단하도록 접근 제어 로직 업데이트

<br/>

## 📝 작업 상세 내용
**회원 프로필 컴포넌트 리팩토링**
- 회원 데이터 처리를 중앙화하고 코드 유지보수를 간소화하기 위해 `MyInfoSection` 및 모든 관련 사용을 단일 `memberProfileData` prop을 받도록 리팩토링하여 `name`, `bojHandle`, `introduction`, `rating`, `div` 등의 개별 props 제거
- 올바른 레이팅 정보가 표시되도록 `HitingSection` 및 부모 컴포넌트를 `memberProfileData`에서 `ratingRecords`를 전달하도록 업데이트

**UI 일관성 개선**
- 회원가입, 회원 상세, 마이 페이지 화면에서 일관된 룩앤필을 위해 일반 `<p>` 요소 및 오류 메시지를 `Label` 컴포넌트로 교체
- 더 견고한 UI를 위해 `AnnouncementListSection`에서 레이팅 시즌 제목의 조건부 렌더링 추가

**새로운 기능 및 개선사항**
- 다이얼로그 메시지에서 계좌번호를 추출하고 복사하는 로직과 복사 성공 시 사용자에게 피드백을 포함하여 `GreetingDialog`에 계좌번호 클립보드 복사 버튼 추가
- 사용자가 solved.ac 프로필 정보를 새로고침하는 데 도움이 되는 추가 안내 텍스트를 `BojGuideDialog`에 포함

**버그 수정 및 오류 처리**
- 더 명확한 의사소통을 위해 `Label`을 사용하여 모바일 회원 상세 및 마이 페이지 화면의 오류 처리 및 메시징 개선
- `HitingSection`에서 division 값이 하드코딩되어 있던 버그 수정, 이제 `record.division`을 올바르게 사용

**접근 제어 조정**
- `ASSOCIATE` 사용자는 계속 진행할 수 있도록 허용하고 `GUEST` 역할의 사용자만 차단하도록 `AuthenticatedUserSection`의 역할 확인 로직 업데이트

<br/>

## 🔗 관련 이슈/PR
- #153 

<br/>

## 💬 기타 참고사항