### PR TITLE
Feat: 이미지 업로드 및 출석/과제 다이얼로그 추가

### DIFF
--- a/apps/intra/src/features/announcement/api/announcement.ts
+++ b/apps/intra/src/features/announcement/api/announcement.ts
@@ -4,6 +4,7 @@ import {
   AnnouncementSummary,
   Announcement,
   CreateAnnouncementRequest,
+  ImageSource,
 } from '@hiarc-platform/shared';
 import { AnnouncementQueryParams } from '../types/request/announcement-query-params';
 import { UpdateAnnouncementRequest } from '../types/request/update-announcement-request';
@@ -102,5 +103,25 @@ export const announcementApi = {
       announcementData
     );
     return Announcement.fromJson(response.data);
+  },
+
+  /**
+   * 이미지 업로드를 위한 presigned URL을 가져오는 API입니다.
+   * @param studyId - 스터디의 ID입니다.
+   * @param contentType - 업로드할 이미지의 콘텐츠 타입입니다.
+   * @returns presigned URL과 업로드 정보를 반환합니다.
+   */
+  GET_IMAGE_UPLOAD_URL: async (studyId: number, contentType: string): Promise<ImageSource> => {
+    console.log('[ADMIN ANNOUNCEMENT API] GET_IMAGE_UPLOAD_URL 요청:', { contentType });
+    try {
+      const response = await apiClient.get<ImageSource>(
+        `/studies/${studyId}/instructor/image/upload-url?contentType=${encodeURIComponent(contentType)}`
+      );
+      console.log('[ADMIN ANNOUNCEMENT API] GET_IMAGE_UPLOAD_URL 응답:', response.data);
+      return response.data;
+    } catch (error) {
+      console.error('[ADMIN ANNOUNCEMENT API] GET_IMAGE_UPLOAD_URL 에러:', error);
+      throw error;
+    }
   },
 };

--- a/apps/intra/src/features/announcement/hooks/mutation/use-image-upload.ts
+++ b/apps/intra/src/features/announcement/hooks/mutation/use-image-upload.ts
@@ -1,0 +1,38 @@
+import { useMutation } from '@tanstack/react-query';
+import axios from 'axios';
+
+import { ImageSource } from '@hiarc-platform/shared';
+import { announcementApi } from '../../api/announcement';
+
+interface UploadImageParams {
+  studyId: number;
+  file: File;
+}
+
+export const useImageUpload: () => ReturnType<
+  typeof useMutation<ImageSource, unknown, UploadImageParams>
+> = () =>
+  useMutation<ImageSource, unknown, UploadImageParams>({
+    mutationFn: async ({ studyId, file }: UploadImageParams): Promise<ImageSource> => {
+      // 1. presigned URL 가져오기 (파일의 MIME type 전달)
+      const { resourceKey, url } = await announcementApi.GET_IMAGE_UPLOAD_URL(studyId, file.type);
+
+      // 2. presigned URL로 이미지 업로드
+      const formData = new FormData();
+      formData.append('file', file);
+
+      await axios.put(url ?? '', file, {
+        headers: {
+          'Content-Type': file.type,
+        },
+      });
+
+      // 3. 업로드된 이미지의 URL 반환 (presigned URL에서 query parameters 제거)
+      const [uploadedUrl] = (url ?? '').split('?');
+
+      return {
+        resourceKey,
+        url: uploadedUrl,
+      };
+    },
+  });

--- a/apps/intra/src/features/announcement/hooks/mutation/use-update-instructor-announcement.ts
+++ b/apps/intra/src/features/announcement/hooks/mutation/use-update-instructor-announcement.ts
@@ -22,8 +22,13 @@ export const useUpdateInstructorAnnouncement = () => {
       queryClient.invalidateQueries({ queryKey: ['announcements'] });
       queryClient.invalidateQueries({ queryKey: ['announcement', announcementId.toString()] });
       queryClient.invalidateQueries({ queryKey: ['study', studyId] });
-      DialogUtil.showSuccess('공지사항이 성공적으로 업데이트되었습니다.', () => {
-        router.back();
+      DialogUtil.showSuccess('공지사항이 성공적으로 수정되었습니다.', () => {
+        const targetStudyId = studyId;
+        if (targetStudyId) {
+          router.push(`/study/${studyId}`);
+        } else {
+          router.back();
+        }
       });
     },
   });

--- a/apps/intra/src/features/announcement/hooks/page/use-announcement-edit-page-state.ts
+++ b/apps/intra/src/features/announcement/hooks/page/use-announcement-edit-page-state.ts
@@ -1,9 +1,12 @@
 import { useRouter, useParams, useSearchParams } from 'next/navigation';
-import { CreateAnnouncementRequest } from '@hiarc-platform/shared';
+import { useState } from 'react';
+import { CreateAnnouncementRequest, CreateAnnouncementForm } from '@hiarc-platform/shared';
 import { useSemesterStoreInit } from '@/shared/hooks/use-semester-store';
 import useAnnouncement from '../query/use-announcement';
 import { useUpdateInstructorAnnouncement } from '../mutation/use-update-instructor-announcement';
 import { useStudyOptions } from '@/features/study/hooks/study-instructor/query/use-study-options';
+import { useImageUpload } from '../mutation/use-image-upload';
+import { DialogUtil } from '@hiarc-platform/ui';
 
 export function useAnnouncementEditPageState() {
   const router = useRouter();
@@ -16,22 +19,122 @@ export function useAnnouncementEditPageState() {
 
   const { data: announcement, isLoading, error } = useAnnouncement(id.toString());
   const { mutate: updateAnnouncement } = useUpdateInstructorAnnouncement();
+  const { mutate: uploadImage } = useImageUpload();
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   // 스터디 옵션을 위한 semester store 초기화
   useSemesterStoreInit();
   const { data: studyOptions } = useStudyOptions(semesterId || announcement?.semesterId);
 
-  const handleSubmit = (
-    data: CreateAnnouncementRequest,
+  const handleSubmit = async (
+    data: CreateAnnouncementForm,
     isEditMode: boolean,
     announcementId?: number
-  ): void => {
-    if (announcementId) {
-      updateAnnouncement({
-        studyId: studyId || announcement?.studyId || 0,
-        announcementId,
-        data,
-      });
+  ): Promise<void> => {
+    if (isSubmitting) {
+      return;
+    }
+    setIsSubmitting(true);
+
+    try {
+      // 1. 먼저 기존 이미지 키들을 수집 (업로드하지 않음)
+      const existingImageKeys: string[] = [];
+      if (data.imageSources && data.imageSources.length > 0) {
+        data.imageSources.forEach((imageSource) => {
+          if (imageSource.resourceKey) {
+            existingImageKeys.push(imageSource.resourceKey);
+          }
+        });
+      }
+      console.log('기존 이미지 키들 (업로드 안함):', existingImageKeys);
+
+      // 2. 새로 추가한 이미지들만 업로드
+      const newImageKeys: string[] = [];
+      if (data.images && data.images.length > 0) {
+        DialogUtil.showInfo('새 이미지를 업로드하고 있습니다...');
+
+        try {
+          // studyId 확인
+          const targetStudyId = studyId || announcement?.studyId || 1;
+
+          // 이미지를 순차적으로 업로드
+          for (let i = 0; i < data.images.length; i++) {
+            const file = data.images[i];
+            console.log(`새 이미지 업로드 시작 ${i + 1}/${data.images.length}:`, file.name);
+
+            const imageKey = await new Promise<string>((resolve, reject) => {
+              uploadImage(
+                { studyId: targetStudyId, file },
+                {
+                  onSuccess: (imageSource) => {
+                    console.log(`새 이미지 업로드 성공 ${i + 1}:`, imageSource.resourceKey);
+                    resolve(imageSource.resourceKey ?? '');
+                  },
+                  onError: (error) => {
+                    console.error(`새 이미지 업로드 실패 ${i + 1}:`, error);
+                    reject(error);
+                  },
+                }
+              );
+            });
+
+            newImageKeys.push(imageKey);
+          }
+
+          console.log('새 이미지 업로드 완료:', newImageKeys);
+          DialogUtil.hideAllDialogs();
+        } catch (error) {
+          console.error('새 이미지 업로드 에러:', error);
+          DialogUtil.showError('새 이미지 업로드에 실패했습니다. 다시 시도해주세요.');
+          setIsSubmitting(false);
+          return;
+        }
+      }
+
+      // 3. 최종 이미지 키 배열 생성: 기존 키들 + 새 키들 (순서 보장)
+      const finalImageKeys: string[] = [
+        ...existingImageKeys, // 기존 이미지 키들이 앞에
+        ...newImageKeys, // 새 이미지 키들이 뒤에
+      ];
+      console.log('최종 이미지 키 배열:', finalImageKeys);
+
+      // CreateAnnouncementRequest로 변환
+      const requestData: CreateAnnouncementRequest = {
+        title: data.title,
+        place: data.place,
+        scheduleStartAt: data.scheduleStartAt,
+        scheduleEndAt: data.scheduleEndAt,
+        content: data.content,
+        announcementType: data.announcementType,
+        applicationUrl: data.applicationUrl,
+        applicationStartAt: data.applicationStartAt,
+        applicationEndAt: data.applicationEndAt,
+        isPublic: data.isPublic,
+        studyId: data.studyId,
+        lectureRound: data.lectureRound,
+        imageKeys: finalImageKeys.length > 0 ? finalImageKeys : null,
+        attachmentUrls: data.attachmentUrls,
+      };
+
+      if (announcementId) {
+        updateAnnouncement(
+          {
+            studyId: studyId || announcement?.studyId || 0,
+            announcementId,
+            data: requestData,
+          },
+          {
+            onSettled: () => {
+              setIsSubmitting(false);
+            },
+          }
+        );
+      } else {
+        setIsSubmitting(false);
+      }
+    } catch (error) {
+      DialogUtil.showError('공지사항 수정에 실패했습니다.');
+      setIsSubmitting(false);
     }
   };
 

--- a/apps/intra/src/features/announcement/hooks/page/use-announcement-write-page-state.ts
+++ b/apps/intra/src/features/announcement/hooks/page/use-announcement-write-page-state.ts
@@ -1,13 +1,18 @@
 import { useRouter, useSearchParams } from 'next/navigation';
-import { CreateAnnouncementRequest } from '@hiarc-platform/shared';
+import { useState } from 'react';
+import { CreateAnnouncementRequest, CreateAnnouncementForm } from '@hiarc-platform/shared';
 import { useSemesterStoreInit, useSemesterStore } from '@/shared/hooks/use-semester-store';
 import useCreateStudyAnnouncement from '@/features/study/hooks/study-instructor/mutation/use-create-study-announcement';
 import { useStudyOptions } from '@/features/study/hooks/study-instructor/query/use-study-options';
+import { useImageUpload } from '../mutation/use-image-upload';
+import { DialogUtil } from '@hiarc-platform/ui';
 
 export function useAnnouncementWritePageState() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { mutate: createAnnouncement } = useCreateStudyAnnouncement();
+  const { mutate: uploadImage } = useImageUpload();
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   // Get query parameters
   const initialType = searchParams.get('type') as
@@ -27,12 +32,105 @@ export function useAnnouncementWritePageState() {
   const targetSemesterId = semesterId ? Number(semesterId) : selectedSemesterId;
   const { data: studyOptions = [] } = useStudyOptions(Number(targetSemesterId));
 
-  const handleSubmit = (data: CreateAnnouncementRequest): void => {
-    const mutationData = initialStudyId
-      ? { studyId: Number(initialStudyId), announcementData: data }
-      : data;
+  const handleSubmit = async (data: CreateAnnouncementForm): Promise<void> => {
+    if (isSubmitting) {
+      return;
+    }
+    setIsSubmitting(true);
 
-    createAnnouncement(mutationData);
+    try {
+      const imageKeys: string[] = [];
+
+      // 이미지가 있는 경우 업로드 처리
+      if (data.images && data.images.length > 0) {
+        DialogUtil.showInfo('이미지를 업로드하고 있습니다...');
+
+        try {
+          // studyId 확인 - 필수값이므로 초기값이나 현재 선택된 값 사용
+          const targetStudyId = initialStudyId ? Number(initialStudyId) : 1; // 기본값 설정
+
+          // 이미지를 순차적으로 업로드
+          for (let i = 0; i < data.images.length; i++) {
+            const file = data.images[i];
+            console.log(`이미지 업로드 시작 ${i + 1}/${data.images.length}:`, file.name);
+
+            const imageKey = await new Promise<string>((resolve, reject) => {
+              uploadImage(
+                { studyId: targetStudyId, file },
+                {
+                  onSuccess: (imageSource) => {
+                    console.log(`이미지 업로드 성공 ${i + 1}:`, imageSource.resourceKey);
+                    resolve(imageSource.resourceKey ?? '');
+                  },
+                  onError: (error) => {
+                    console.error(`이미지 업로드 실패 ${i + 1}:`, error);
+                    reject(error);
+                  },
+                }
+              );
+            });
+
+            imageKeys.push(imageKey);
+          }
+
+          console.log('모든 이미지 업로드 완료:', imageKeys);
+          DialogUtil.hideAllDialogs();
+        } catch (error) {
+          console.error('이미지 업로드 에러:', error);
+          DialogUtil.showError('이미지 업로드에 실패했습니다. 다시 시도해주세요.');
+          setIsSubmitting(false);
+          return;
+        }
+      }
+
+      // CreateAnnouncementRequest로 변환
+      const requestData: CreateAnnouncementRequest = {
+        title: data.title,
+        place: data.place,
+        scheduleStartAt: data.scheduleStartAt,
+        scheduleEndAt: data.scheduleEndAt,
+        content: data.content,
+        announcementType: data.announcementType,
+        applicationUrl: data.applicationUrl,
+        applicationStartAt: data.applicationStartAt,
+        applicationEndAt: data.applicationEndAt,
+        isPublic: data.isPublic,
+        studyId: data.studyId,
+        lectureRound: data.lectureRound,
+        imageKeys: imageKeys.length > 0 ? imageKeys : null,
+        attachmentUrls: data.attachmentUrls,
+      };
+
+      const mutationData = initialStudyId
+        ? { studyId: Number(initialStudyId), announcementData: requestData }
+        : requestData;
+
+      createAnnouncement(mutationData, {
+        onSuccess: () => {
+          const successMessage =
+            initialType === 'STUDY'
+              ? '스터디 공지사항이 성공적으로 등록되었습니다.'
+              : '공지사항이 성공적으로 등록되었습니다.';
+          const redirectPath =
+            initialType === 'STUDY' && initialStudyId
+              ? `/study/${initialStudyId}`
+              : '/announcement';
+
+          DialogUtil.showSuccess(successMessage, () => {
+            router.push(redirectPath);
+          });
+        },
+        onError: (error) => {
+          DialogUtil.showServerError(error);
+        },
+        onSettled: () => {
+          setIsSubmitting(false);
+        },
+      });
+    } catch (error) {
+      DialogUtil.showError('공지사항 등록에 실패했습니다.');
+      setIsSubmitting(false);
+    }
   };
 
   const handleGoBack = (): void => {

--- a/apps/intra/src/features/study/components/tab-section/LectureListTab.tsx
+++ b/apps/intra/src/features/study/components/tab-section/LectureListTab.tsx
@@ -6,6 +6,8 @@ import { useRouter } from 'next/navigation';
 import { ShowAttendanceCodeDialogWrapper } from './dialog/ShowAttendanceCodeDialogWrapper';
 import { CreateAssignmentDialogWrapper } from './dialog/CreateAssignmentDialogWrapper';
 import { useDeleteLecture } from '../../hooks/study-instructor/mutation/use-delete-lecture';
+import { CheckAttendanceCodeDialog } from './dialog/CheckAttendanceCodeDialog';
+import { DoAssignmentDialogWrapper } from './dialog/DoAssignmentDialogWrapper';
 
 interface LectureListTabProps {
   isAdmin?: boolean;
@@ -82,6 +84,27 @@ export function LectureListTab({
     );
   };
 
+  const handleCheckAttendanceClick = (lecture: Lecture): void => {
+    DialogUtil.showComponent(
+      <CheckAttendanceCodeDialog
+        studyId={studyId ?? 0}
+        lectureRound={lecture.round ?? 0}
+        lectureName={lecture.title ?? ''}
+        studyName={studyName}
+      />
+    );
+  };
+
+  const handleDoAssignmentClick = (lecture: Lecture) => {
+    DialogUtil.showComponent(
+      <DoAssignmentDialogWrapper
+        studyId={studyId ?? 0}
+        lectureRound={lecture.round ?? 0}
+        lectureId={lecture.round ?? 0}
+      />
+    );
+  };
+
   const handleEditClick = (lecture: Lecture): void => {
     if (!lecture.announcementId) {
       console.error('강의 수정 실패: announcementId가 없습니다.');
@@ -128,6 +151,8 @@ export function LectureListTab({
       onShowAttendanceClick={handleShowAttendanceClick}
       onCreateAssignmentClick={handleCreateAssignmentClick}
       onShowAssignmentClick={handleShowAssignmentClick}
+      onAttendanceCheckClick={handleCheckAttendanceClick}
+      onDoAssignmentClick={handleDoAssignmentClick}
       onEditClick={handleEditClick}
       onDeleteClick={handleDeleteClick}
     />

--- a/apps/intra/src/features/study/components/tab-section/dialog/CheckAttendanceCodeDialog.tsx
+++ b/apps/intra/src/features/study/components/tab-section/dialog/CheckAttendanceCodeDialog.tsx
@@ -1,0 +1,92 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogTitle,
+  DialogUtil,
+  Label,
+} from '@hiarc-platform/ui';
+import { NumberInput } from '@hiarc-platform/ui/src/components/input/number-input';
+import React, { useState } from 'react';
+import { useCheckAttendanceCode } from '@/features/study/hooks';
+
+interface CheckAttendanceCodeDialogProps {
+  studyId: number;
+  lectureRound: number;
+  studyName?: string;
+  lectureName?: string;
+}
+
+export function CheckAttendanceCodeDialog({
+  studyId,
+  lectureRound,
+  studyName,
+  lectureName,
+}: CheckAttendanceCodeDialogProps): React.ReactElement {
+  const [attendanceCode, setAttendanceCode] = useState<string>('');
+  const checkAttendanceMutation = useCheckAttendanceCode();
+
+  const handleCancel = (): void => {
+    DialogUtil.hideAllDialogs();
+  };
+
+  const handleAttendance = (): void => {
+    if (!attendanceCode.trim()) {
+      return;
+    }
+
+    if (!studyId || !lectureRound) {
+      return;
+    }
+
+    checkAttendanceMutation.mutate({
+      studyId,
+      lectureRound,
+      attendanceCode: attendanceCode.trim(),
+    });
+  };
+
+  return (
+    <Dialog open={true} onOpenChange={(open) => !open && handleCancel()}>
+      <DialogContent>
+        <DialogTitle>출석 체크</DialogTitle>
+        {studyName && lectureName && (
+          <ol className="list-disc pl-4 pt-6 text-sm text-gray-600">
+            <li>
+              <Label size="lg">{studyName}</Label>
+            </li>
+            <li>
+              <Label size="lg">
+                {lectureRound}주차 : {lectureName}
+              </Label>
+            </li>
+          </ol>
+        )}
+        <NumberInput
+          className="mt-6 w-full justify-center"
+          length={6}
+          value={attendanceCode}
+          onChange={setAttendanceCode}
+        />
+        <DialogFooter>
+          <div className="mt-6 flex w-full flex-row gap-2">
+            <Button variant="secondary" className="w-full" size="lg" onClick={handleCancel}>
+              <Label size="lg">취소</Label>
+            </Button>
+            <Button
+              className="w-full"
+              size="lg"
+              disabled={attendanceCode.length !== 6 || checkAttendanceMutation.isPending}
+              onClick={handleAttendance}
+            >
+              <Label size="lg">
+                {checkAttendanceMutation.isPending ? '출석 중...' : '출석하기'}
+              </Label>
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/intra/src/features/study/components/tab-section/dialog/DoAssignmentDialogWrapper.tsx
+++ b/apps/intra/src/features/study/components/tab-section/dialog/DoAssignmentDialogWrapper.tsx
@@ -1,0 +1,20 @@
+import { useAssignment } from '@/features/study/hooks';
+import { DoAssignmentDialog } from '@hiarc-platform/ui';
+
+interface DoAssignmentDialogWrapperProps {
+  studyId: number;
+  lectureId: number;
+  lectureRound: number;
+}
+
+export function DoAssignmentDialogWrapper({
+  studyId,
+  lectureId,
+  lectureRound,
+}: DoAssignmentDialogWrapperProps): React.ReactElement {
+  const { data: assignment, isLoading } = useAssignment(studyId, lectureId);
+
+  return (
+    <DoAssignmentDialog assignment={assignment} isLoading={isLoading} lectureRound={lectureRound} />
+  );
+}

--- a/packages/ui/src/components/study/do-assignment-dialog.tsx
+++ b/packages/ui/src/components/study/do-assignment-dialog.tsx
@@ -15,8 +15,6 @@ import Image from 'next/image';
 
 interface DoAssignmentDialogProps {
   lectureRound: number;
-  studyId: number;
-  lectureId: number;
   assignment?: Assignment;
   isLoading?: boolean;
 }


### PR DESCRIPTION
## 🔀 PR 개요
공지사항의 이미지 업로드 기능을 도입하고 출석 및 과제를 위한 새로운 다이얼로그로 강의 탭을 향상
presigned URL 처리 및 업로드 상태 관리를 포함한 이미지 업로드 구현, 이미지 지원을 위한 공지사항 생성 및 편집 플로우 업데이트, 출석 코드 확인 및 과제 제출을 위한 새로운 UI 다이얼로그 추가

<br/>

## 📌 주요 변경 사항
- 보안 직접 업로드를 위한 presigned URL 가져오기를 위한 새로운 API 메서드 `GET_IMAGE_UPLOAD_URL` 추가
- presigned URL을 사용한 이미지 업로드 프로세스 처리를 위한 `useImageUpload` React 훅 구현
- 이미지 업로드를 지원하도록 공지사항 편집 및 작성 훅 업데이트
- 출석 코드 입력을 위한 `CheckAttendanceCodeDialog` 및 과제 제출을 위한 `DoAssignmentDialogWrapper` 추가
- 공지사항 업데이트 및 생성을 위한 성공 및 오류 다이얼로그 개선

<br/>

## 📝 작업 상세 내용
**공지사항 이미지 업로드**
- 스토리지에 대한 보안 직접 업로드를 가능하게 하기 위해 이미지 업로드용 presigned URL을 가져오는 `announcementApi`에 새로운 API 메서드 `GET_IMAGE_UPLOAD_URL` 추가
- 오류 처리를 포함하고 업로드된 이미지의 리소스 키와 URL을 반환하는 presigned URL을 사용한 이미지 업로드 프로세스를 처리하는 `useImageUpload` React 훅 구현

**공지사항 생성 및 편집 플로우**
- 이미지 업로드를 지원하도록 공지사항 편집(`use-announcement-edit-page-state.ts`) 및 작성(`use-announcement-write-page-state.ts`) 훅 업데이트
- 기존 이미지 키 수집, 새 이미지 업로드, 업로드 상태 관리, 이미지 키를 공지사항 페이로드에 통합 포함
- 업로드 중 및 오류 시 사용자 피드백 다이얼로그 표시
- 공지사항 업데이트 및 생성을 위한 성공 및 오류 다이얼로그 개선, 성공적인 작업 후 사용자를 적절히 리디렉션

**강의 탭 개선**
- 출석 코드 입력을 위한 `CheckAttendanceCodeDialog` 및 과제 제출을 위한 `DoAssignmentDialogWrapper` 새로운 다이얼로그 컴포넌트 추가
- 강의 목록 탭에 통합

**기타 UI 조정**
- 새로운 다이얼로그 래퍼 사용을 반영하여 `DoAssignmentDialog` 컴포넌트 props에서 사용하지 않는 `studyId` 및 `lectureId` 매개변수 제거

<br/>

## 🔗 관련 이슈/PR
- #158

<br/>

## 💬 기타 참고사항