### PR TITLE
Deploy: Rating 앱 기록 및 순위 정보 수정 후 배포

### DIFF
--- a/apps/intra/src/features/study/api/study-instructor.ts
+++ b/apps/intra/src/features/study/api/study-instructor.ts
@@ -221,7 +221,7 @@ export const studyInstructorApi = {
 
   CHECK_ASSIGNMENT: async (studyId: number, round: number): Promise<void> => {
     try {
-      await apiClient.post(`/studies/${studyId}/instructor/lecture/${round}/assignment/status`);
+      await apiClient.patch(`/studies/${studyId}/instructor/lecture/${round}/assignment/status`);
     } catch (error) {
       console.error('[STUDY API] CHECK_ASSIGNMENT 에러:', error);
       throw error;


### PR DESCRIPTION
## 🔀 PR 개요
레이팅 앱에서 연속 기록 및 순위 정보가 표시되고 처리되는 방식을 업데이트 후 배포

<br/>

## 📌 주요 변경 사항
- `StreakInformation` 컴포넌트에서 `currentSeasonStreak`을 `number | null`로 받도록 업데이트
- 현재 시즌 연속 기록이 있는 경우에만 현재 시즌 연속 기록 카드 표시
- 가장 관련성 높은 점수 표시를 위해 `fetchRankingData` API 함수의 점수 선택 로직 개선
- `currentSeasonScore` 사용 가능 시 우선 사용, 그렇지 않으면 `totalScore`로 대체하는 로직 구현
- 현재 시즌 연속 기록이 없을 때 빈 정보나 오해를 불러일으킬 수 있는 정보 렌더링 방지

<br/>

## 📝 작업 상세 내용
**연속 기록 정보 표시 개선**
- 현재 시즌 연속 기록이 없을 때 빈 또는 오해를 불러일으킬 수 있는 정보 렌더링을 방지하기 위해 `StreakInformation` 컴포넌트를 `currentSeasonStreak`을 `number | null`로 받도록 업데이트하고, 값이 있는 경우에만 현재 시즌 연속 기록 카드 표시

**순위 데이터 로직 개선**
- 각 사용자에게 가장 관련성 높은 점수가 표시되도록 `fetchRankingData` API 함수를 수정하여 `currentSeasonScore`가 사용 가능한 경우 이를 사용하고, 그렇지 않으면 `totalScore`로 대체하는 로직 구현

<br/>

## 🔗 관련 이슈/PR
- #163 
- #164 

<br/>

## 💬 기타 참고사항