### PR TITLE
Deploy: Hi-Rating SeasonScore 이 아닌 totalScore을 렌더링하는 문제 해결 반영

### DIFF
--- a/apps/intra/package.json
+++ b/apps/intra/package.json
@@ -23,6 +23,7 @@
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@vercel/analytics": "^1.5.0",
+    "@vercel/speed-insights": "^1.2.0",
     "autoprefixer": "^10.0.0",
     "axios": "^1.7.9",
     "date-fns": "^4.1.0",

--- a/apps/intra/src/app/layout.tsx
+++ b/apps/intra/src/app/layout.tsx
@@ -2,6 +2,7 @@ import Footer from '@/shared/components/ui/Footer';
 import ConditionalHeader from '@/shared/components/ui/ConditionalHeader';
 import type { Metadata } from 'next';
 import { Analytics } from '@vercel/analytics/next';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 
 // 로컬 폰트 import
 import '@fontsource/pretendard/400.css';
@@ -32,6 +33,7 @@ export default function RootLayout({
       <body className="flex min-h-screen flex-col">
         <Providers>
           <Analytics />
+          <SpeedInsights />
           <ConditionalHeader />
           <main className="flex-1">{children}</main>
           <div className="hidden md:block">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,6 +211,9 @@ importers:
       '@vercel/analytics':
         specifier: ^1.5.0
         version: 1.5.0(next@14.0.0)(react@18.3.1)
+      '@vercel/speed-insights':
+        specifier: ^1.2.0
+        version: 1.2.0(next@14.0.0)(react@18.3.1)
       autoprefixer:
         specifier: ^10.0.0
         version: 10.4.21(postcss@8.5.6)
@@ -4450,6 +4453,34 @@ packages:
         optional: true
     dependencies:
       react: 19.1.1
+    dev: false
+
+  /@vercel/speed-insights@1.2.0(next@14.0.0)(react@18.3.1):
+    resolution: {integrity: sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==}
+    requiresBuild: true
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+    dependencies:
+      next: 14.0.0(react-dom@18.3.1)(react@18.3.1)
+      react: 18.3.1
     dev: false
 
   /@vitejs/plugin-react@4.7.0(vite@6.3.5):


### PR DESCRIPTION
## 🔀 PR 개요
순위 점수 처리 및 표시 방식을 업데이트하여 사용자의 현재 시즌 점수가 없는 경우를 지원하도록 개선

<br/>

## 📌 주요 변경 사항
- 현재 시즌 점수가 없는 사용자를 고려하여 `RankingItem` 인터페이스의 `currentSeasonScore` 속성을 nullable로 변경
- 각 순위 항목에 대해 `totalScore`와 `currentSeasonScore` 필드를 모두 반환하도록 `fetchRankingData` 함수 업데이트
- `currentSeasonScore` 사용 가능 시 표시하고, 그렇지 않으면 `totalScore`로 대체하는 UI 로직 구현
- 기존 `total` 필드를 `totalScore`와 nullable `currentSeasonScore` 필드로 교체하여 컴포넌트 props 및 상태 정의 업데이트

<br/>

## 📝 작업 상세 내용
**타입 및 API 업데이트**
- 현재 시즌 점수가 없을 수 있는 사용자를 고려하여 `RankingItem` 인터페이스에서 `currentSeasonScore` 속성을 nullable로 변경
- 하위 컴포넌트가 두 값 모두에 접근할 수 있도록 각 순위 항목에 대해 `totalScore`와 `currentSeasonScore` 필드를 모두 반환하도록 `fetchRankingData` 함수 업데이트

**컴포넌트 및 UI 변경사항**
- 기존 `total` 필드를 대체하여 `totalScore`와 nullable `currentSeasonScore` 필드를 포함하도록 `RankingContainerProps` 및 관련 상태 정의 업데이트
- 사용 가능한 경우 `currentSeasonScore`를 표시하고, 그렇지 않으면 총점 표시를 위해 `totalScore`로 대체하도록 `RankingContainer` 컴포넌트 수정하여 UI가 각 사용자에게 가장 관련성 높은 점수를 정확히 반영하도록 보장

<br/>

## 🔗 관련 이슈/PR
- #171 

<br/>

## 💬 기타 참고사항