### PR TITLE
fix: 권한 문제 해결 #156

### DIFF
--- a/apps/intra/src/app/announcement/[id]/page.tsx
+++ b/apps/intra/src/app/announcement/[id]/page.tsx
@@ -30,18 +30,22 @@ export async function generateStaticParams() {
 export default async function AnnouncementDetail({
   params,
 }: PageProps): Promise<React.ReactElement> {
-  let announcement;
+  let announcement = null;
 
   try {
     announcement = await announcementApi.GET_ANNOUNCEMENT(params.id);
-  } catch (error) {
-    notFound();
+  } catch (error: any) {
+    // 404는 notFound 페이지로
+    if (error?.response?.status === 404 || error?.status === 404) {
+      notFound();
+    }
+    // 그 외 에러(403 권한 없음 등)는 클라이언트에서 처리
   }
 
   return (
     <PageLayout
-      desktopChildren={<DesktopAnnouncementDetailPage announcement={announcement} />}
-      mobileChildren={<MobileAnnouncementDetailPage announcement={announcement} />}
+      desktopChildren={<DesktopAnnouncementDetailPage announcement={announcement} id={params.id} />}
+      mobileChildren={<MobileAnnouncementDetailPage announcement={announcement} id={params.id} />}
     />
   );
 }

--- a/apps/intra/src/features/announcement/hooks/query/use-announcement.ts
+++ b/apps/intra/src/features/announcement/hooks/query/use-announcement.ts
@@ -8,11 +8,18 @@ import { announcementApi } from '../../api/announcement';
 // 모듈 레벨에서 에러를 추적하는 Set (전역적으로 중복 방지)
 const shownErrorIds = new Set<string>();
 
-export default function useAnnouncement(id: string): UseQueryResult<Announcement, Error> {
+interface UseAnnouncementOptions {
+  enabled?: boolean;
+}
+
+export default function useAnnouncement(
+  id: string,
+  options?: UseAnnouncementOptions
+): UseQueryResult<Announcement, Error> {
   const query = useQuery({
     queryKey: ['announcement', id],
     queryFn: () => announcementApi.GET_ANNOUNCEMENT(id),
-    enabled: Boolean(id),
+    enabled: options?.enabled !== undefined ? options.enabled && Boolean(id) : Boolean(id),
     retry: false,
   });
 

--- a/apps/intra/src/features/announcement/pages/announcement-detail/desktop-announcement-detail-page.tsx
+++ b/apps/intra/src/features/announcement/pages/announcement-detail/desktop-announcement-detail-page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   AnnouncementContentSection,
   AnnouncementIndicatorSection,
@@ -5,12 +7,30 @@ import {
 } from '@hiarc-platform/ui';
 import { Announcement, AnnnouncementType } from '@hiarc-platform/shared';
 import { AnnouncementNavigationSection } from './components/announcement-navigation-section';
+import useAnnouncement from '../../hooks/query/use-announcement';
 
 interface DesktopAnnouncementDetailPageProps {
-  announcement: Announcement;
+  announcement: Announcement | null;
+  id: string;
 }
 
-export function DesktopAnnouncementDetailPage({ announcement }: DesktopAnnouncementDetailPageProps): React.ReactElement {
+export function DesktopAnnouncementDetailPage({
+  announcement: initialAnnouncement,
+  id,
+}: DesktopAnnouncementDetailPageProps): React.ReactElement {
+  const { data: clientAnnouncement, isLoading } = useAnnouncement(id, {
+    enabled: !initialAnnouncement,
+  });
+
+  const announcement = initialAnnouncement || clientAnnouncement;
+
+  if (!announcement || isLoading) {
+    return (
+      <div className="flex min-h-[400px] flex-col items-center justify-center">
+        <div>로딩 중...</div>
+      </div>
+    );
+  }
   const processedAnnouncement = {
     ...announcement,
     announcementTitle: announcement.announcementTitle || '제목 없음',
@@ -21,9 +41,7 @@ export function DesktopAnnouncementDetailPage({ announcement }: DesktopAnnouncem
     scheduleStartAt: announcement.scheduleStartAt
       ? new Date(announcement.scheduleStartAt)
       : undefined,
-    scheduleEndAt: announcement.scheduleEndAt
-      ? new Date(announcement.scheduleEndAt)
-      : undefined,
+    scheduleEndAt: announcement.scheduleEndAt ? new Date(announcement.scheduleEndAt) : undefined,
     applicationStartAt: announcement.applicationStartAt
       ? new Date(announcement.applicationStartAt)
       : undefined,

--- a/apps/intra/src/features/announcement/pages/announcement-detail/mobile-announcement-detail-page.tsx
+++ b/apps/intra/src/features/announcement/pages/announcement-detail/mobile-announcement-detail-page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   AnnouncementContentSection,
   AnnouncementIndicatorSection,
@@ -5,14 +7,30 @@ import {
 } from '@hiarc-platform/ui';
 import { Announcement, AnnnouncementType } from '@hiarc-platform/shared';
 import { AnnouncementNavigationSection } from './components/announcement-navigation-section';
+import useAnnouncement from '../../hooks/query/use-announcement';
 
 interface MobileAnnouncementDetailPageProps {
-  announcement: Announcement;
+  announcement: Announcement | null;
+  id: string;
 }
 
 export function MobileAnnouncementDetailPage({
-  announcement,
+  announcement: initialAnnouncement,
+  id,
 }: MobileAnnouncementDetailPageProps): React.ReactElement {
+  const { data: clientAnnouncement, isLoading } = useAnnouncement(id, {
+    enabled: !initialAnnouncement,
+  });
+
+  const announcement = initialAnnouncement || clientAnnouncement;
+
+  if (!announcement || isLoading) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[400px]">
+        <div>로딩 중...</div>
+      </div>
+    );
+  }
   const processedAnnouncement = {
     ...announcement,
     announcementTitle: announcement.announcementTitle || '제목 없음',


### PR DESCRIPTION
## 🔀 PR 개요

공지사항 상세 페이지의 에러 핸들링 개선 및 클라이언트 사이드 데이터 페칭 지원. 서버에서 공지사항을 찾지 못한 경우 적절한 에러 페이지 표시, 데이터가 없는 경우 클라이언트에서 재시도 및 로딩 상태 표시

<br/>

## 📌 주요 변경 사항

- 공지사항 상세 페이지 404 에러 핸들링 개선
- 클라이언트 사이드 데이터 페칭을 위한 fallback 로직 추가
- `useAnnouncement` 훅에 조건부 페칭 옵션 추가
- 데스크톱 및 모바일 상세 페이지 컴포넌트에 클라이언트 사이드 페칭 및 로딩 상태 지원
- 공지사항 날짜 처리 코드 포맷팅 개선

<br/>

## 📝 작업 상세 내용

**에러 핸들링 및 데이터 페칭 개선:**
- `AnnouncementDetail` 페이지에서 404 에러 발생 시 notFound 페이지로 리다이렉트 처리
- 상세 컴포넌트에 공지사항 데이터와 `id` prop 모두 전달하여 데이터 누락 시 클라이언트 사이드 페칭 가능하도록 개선
- `useAnnouncement` 훅에 `enabled` 옵션 추가로 필요한 경우에만 조건부 페칭 트리거
- 서버 사이드 렌더링 실패 시 클라이언트에서 데이터 재시도 메커니즘 구현

**컴포넌트 업데이트:**
- `DesktopAnnouncementDetailPage` 및 `MobileAnnouncementDetailPage` 리팩토링
- `announcement`를 `Announcement | null` 타입으로 수정하고 `id` prop 추가
- 초기 데이터가 없을 경우 `useAnnouncement` 훅을 통한 클라이언트 사이드 데이터 페칭
- 데이터 로딩 중 일관된 로딩 상태 표시
- 공지사항 날짜 처리 로직의 코드 포맷팅 및 일관성 개선

<br/>

## 🔗 관련 이슈/PR

- #156 

<br/>

## 💬 기타 참고사항